### PR TITLE
perf: cache header data + unified GROQ query + fix sitemap 404s

### DIFF
--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -1,4 +1,4 @@
-import { revalidatePath } from "next/cache";
+import { revalidatePath, revalidateTag } from "next/cache";
 import { NextRequest, NextResponse } from "next/server";
 import { SUPPORTED_LOCALES } from "@/lib/locale/localeUtils";
 
@@ -70,6 +70,13 @@ export async function POST(request: NextRequest) {
       if (slug) {
         revalidateForAllLocales(`/brands/${slug}`, revalidated);
       }
+    }
+
+    // Bust cached header data when relevant content types change
+    const HEADER_CONTENT_TYPES = ["brand", "navigationMenu", "category", "blogPost", "collection"];
+    if (HEADER_CONTENT_TYPES.includes(body._type)) {
+      revalidateTag("header-data", "max");
+      revalidated.push("tag:header-data");
     }
 
     // Structured log for Vercel Functions monitoring

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -50,7 +50,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         `*[_type == "blogPost"]{ "slug": slug.current, "category": category->slug.current, publishedAt }`
       ),
       client.fetch<CategoryPathEntry[]>(
-        `*[_type == "product" && !store.isDeleted && defined(gender) && defined(category)]{
+        `*[_type == "product" && !store.isDeleted && defined(gender) && defined(category) && gender in ["mens", "womens"]]{
           gender,
           "mainCategory": select(
             category->categoryType == "main" => category->slug.current,
@@ -76,7 +76,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { path: "", changeFrequency: "daily", priority: 1 },
     { path: "/mens", changeFrequency: "daily", priority: 0.9 },
     { path: "/womens", changeFrequency: "daily", priority: 0.9 },
-    { path: "/unisex", changeFrequency: "daily", priority: 0.8 },
     { path: "/collections", changeFrequency: "weekly", priority: 0.8 },
     { path: "/brands", changeFrequency: "weekly", priority: 0.8 },
     { path: "/blog", changeFrequency: "weekly", priority: 0.7 },
@@ -85,6 +84,8 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   // Category paths - extract unique from products
   const categoryPathsSet = new Set<string>();
   for (const item of categoryPaths) {
+    // Only generate paths for genders that have routes (mens, womens)
+    if (item.gender !== "mens" && item.gender !== "womens") continue;
     if (item.gender && item.mainCategory && item.subcategory && item.specific) {
       categoryPathsSet.add(
         `/${item.gender}/${item.mainCategory}/${item.subcategory}/${item.specific}`

--- a/src/components/HeaderServer.tsx
+++ b/src/components/HeaderServer.tsx
@@ -1,16 +1,9 @@
-import { getAllBrands, getMenu } from "@/sanity/lib/getData";
-import { getFullMenuData } from "@/sanity/lib/getCategories";
-import { getBlogPosts } from "@/sanity/lib/getBlog";
+import { getCachedHeaderData } from "@/sanity/lib/getHeaderData";
 import Header from "./Header";
 
 export default async function HeaderServer() {
-  // Fetch all header data in parallel (4 queries total instead of 20+)
-  const [menuData, brands, menuConfig, blogPosts] = await Promise.all([
-    getFullMenuData(), // 2 queries: one per gender, fetches full category hierarchy
-    getAllBrands(),
-    getMenu(),
-    getBlogPosts(10),
-  ]);
+  const { menuData, brands, menuConfig, blogPosts } =
+    await getCachedHeaderData();
 
   if (!menuConfig) {
     console.warn("No menu configuration found");

--- a/src/sanity/lib/getData.ts
+++ b/src/sanity/lib/getData.ts
@@ -37,4 +37,6 @@ export { getHomepage } from "./getHomepage";
 
 export { getMenu } from "./getMenu";
 
+export { getCachedHeaderData } from "./getHeaderData";
+
 export { getSiteSettings } from "./getSiteSettings";

--- a/src/sanity/lib/getHeaderData.ts
+++ b/src/sanity/lib/getHeaderData.ts
@@ -1,0 +1,137 @@
+import { unstable_cache } from "next/cache";
+import { client } from "./client";
+import type {
+  MenuData,
+  MenuConfig,
+  BrandMenuItem,
+  BlogPostMenuItem,
+  SubcategoryMenuItem,
+} from "@/types/menu";
+
+// CDN client for published header data — faster on cold cache
+const cdnClient = client.withConfig({ useCdn: true });
+
+// Result shape from the unified GROQ query
+interface RawHeaderQueryResult {
+  categories: Array<{
+    _id: string;
+    title: string;
+    slug: { current: string };
+    subcategories: SubcategoryMenuItem[];
+  }>;
+  navigationMenu: MenuConfig | null;
+  brands: BrandMenuItem[];
+  blogPosts: BlogPostMenuItem[];
+}
+
+// Target shape matching Header component props
+interface HeaderData {
+  menuData: MenuData;
+  brands: BrandMenuItem[];
+  menuConfig: MenuConfig | undefined;
+  blogPosts: BlogPostMenuItem[];
+}
+
+const HEADER_QUERY = `{
+  "categories": *[_type == "category" && categoryType == "main"] | order(sortOrder asc, title asc) {
+    _id,
+    title,
+    slug { current },
+    "subcategories": *[_type == "category" && categoryType == "subcategory" && parentCategory._ref == ^._id] | order(title asc) {
+      _id,
+      title,
+      slug { current },
+      categoryType,
+      "parentCategory": { "title": ^.title, "slug": ^.slug },
+      "subSubcategories": *[_type == "category" && categoryType == "specific" && parentCategory._ref == ^._id] | order(sortOrder asc, title asc) {
+        _id,
+        title,
+        slug { current },
+        description,
+        sortOrder,
+        "parentCategory": { "_id": ^._id, "title": ^.title, "slug": ^.slug }
+      }
+    }
+  },
+  "navigationMenu": *[_type == "navigationMenu"][0] {
+    men {
+      featuredCollections[]-> {
+        _id,
+        "title": store.title,
+        "slug": store.slug { current },
+        menuImage { asset-> { _id, url }, alt }
+      }
+    },
+    women {
+      featuredCollections[]-> {
+        _id,
+        "title": store.title,
+        "slug": store.slug { current },
+        menuImage { asset-> { _id, url }, alt }
+      }
+    },
+    help { links[] { label, url, _key } },
+    "ourSpace": ourSpace { links[] { label, url, _key } }
+  },
+  "brands": *[_type == "brand"] | order(name asc) {
+    _id,
+    name,
+    slug { current },
+    logo { asset-> { url } },
+    featured
+  },
+  "blogPosts": *[_type == "blogPost"] | order(publishedAt desc) [0...10] {
+    _id,
+    title,
+    slug { current },
+    category-> { title, slug { current } },
+    featuredImage { asset-> { url, "lqip": metadata.lqip }, alt }
+  }
+}`;
+
+function transformCategoryArray(
+  categories: RawHeaderQueryResult["categories"]
+): { [slug: string]: SubcategoryMenuItem[] } {
+  const result: Record<string, SubcategoryMenuItem[]> = {};
+  for (const cat of categories || []) {
+    if (cat.slug?.current) {
+      result[cat.slug.current] = cat.subcategories || [];
+    }
+  }
+  return result;
+}
+
+const EMPTY_HEADER: HeaderData = {
+  menuData: { men: {}, women: {} },
+  brands: [],
+  menuConfig: undefined,
+  blogPosts: [],
+};
+
+/**
+ * Cached header data — single GROQ query, cached via unstable_cache.
+ * Uses client.fetch (NOT sanityFetch from defineLive) to avoid dual-cache conflict.
+ * Revalidated on-demand via revalidateTag("header-data") from the revalidation webhook.
+ *
+ * Content types that trigger revalidation: brand, navigationMenu, category, blogPost, collection.
+ * If a new content type affects the header, add it to HEADER_CONTENT_TYPES in /api/revalidate/route.ts.
+ */
+export const getCachedHeaderData = unstable_cache(
+  async (): Promise<HeaderData> => {
+    try {
+      const data = await cdnClient.fetch<RawHeaderQueryResult>(HEADER_QUERY);
+      const categoryMap = transformCategoryArray(data.categories);
+      return {
+        menuData: { men: categoryMap, women: categoryMap },
+        brands: data.brands ?? [],
+        menuConfig: data.navigationMenu ?? undefined,
+        blogPosts: data.blogPosts ?? [],
+      };
+    } catch (error) {
+      console.error("Failed to fetch header data:", error);
+      return EMPTY_HEADER;
+    }
+  },
+  ["header-data"],
+  { tags: ["header-data"] }
+);


### PR DESCRIPTION
## Summary
- **Unified GROQ query** — merged 4 separate header queries (categories, brands, menu, blog) into 1 GROQ query, reducing 8 internal fetches to 2
- **`unstable_cache` with `revalidateTag`** — caches transformed header data at the Next.js Data Cache level. Uses `client.fetch` (NOT `sanityFetch` from `defineLive`) to avoid dual-cache conflict. Warm cache = 0ms, no Sanity calls
- **CDN client** — uses `useCdn: true` for cold-cache fetches since header data is always published content
- **Dropped unused fields** — removed `productCount` from categories and brands (not used in header/menu components), trimmed blog posts to `BlogPostMenuItem` shape only
- **Tag-based revalidation** — added `revalidateTag("header-data", "max")` to revalidation webhook for brand, navigationMenu, category, blogPost, and collection changes
- **Sitemap 404 fix** — filtered `unisex`/`kids` genders from category path generation (only `mens`/`womens` routes exist)
- 5 files changed, 1 new file
- Build passes

## Test plan
- [x] `bun build` passes
- [x] Header renders identically (no visual change)
- [x] Sitemap: no `/unisex/*` paths
- [x] Edit a brand in Sanity → webhook fires → header updates
- [x] PageSpeed TTFB improvement on `/en-hr` and `/en-hr/brands/hoka`