### PR TITLE
v2.14.0: editorial image links, header caching, CLS fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zone2run",
-  "version": "2.13.0",
+  "version": "2.14.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/sanity.types.ts
+++ b/sanity.types.ts
@@ -980,6 +980,117 @@ export type BlogCategory = {
   };
 };
 
+export type Collection = {
+  _id: string;
+  _type: "collection";
+  _createdAt: string;
+  _updatedAt: string;
+  _rev: string;
+  hidden?: string;
+  titleProxy?: ProxyString;
+  slugProxy?: ProxyString;
+  description?: string;
+  vector?: {
+    asset?: {
+      _ref: string;
+      _type: "reference";
+      _weak?: boolean;
+      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+    };
+    media?: unknown;
+    hotspot?: SanityImageHotspot;
+    crop?: SanityImageCrop;
+    _type: "image";
+  };
+  showHero?: boolean;
+  hero?: Hero;
+  modules?: Array<{
+    asset?: {
+      _ref: string;
+      _type: "reference";
+      _weak?: boolean;
+      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+    };
+    media?: unknown;
+    hotspot?: SanityImageHotspot;
+    crop?: SanityImageCrop;
+    _type: "image";
+    _key: string;
+  }>;
+  featured?: boolean;
+  sortOrder?: number;
+  isActive?: boolean;
+  menuImage?: {
+    asset?: {
+      _ref: string;
+      _type: "reference";
+      _weak?: boolean;
+      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+    };
+    media?: unknown;
+    hotspot?: SanityImageHotspot;
+    crop?: SanityImageCrop;
+    alt?: string;
+    _type: "image";
+  };
+  gridLayout?: "4col" | "3col";
+  heroImage?: {
+    image?: {
+      asset?: {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+      };
+      media?: unknown;
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      alt?: string;
+      _type: "image";
+    };
+    caption?: string;
+  };
+  productsPerImage?: 2 | 4 | 6 | 8;
+  editorialImages?: Array<{
+    image?: {
+      asset?: {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+      };
+      media?: unknown;
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      alt?: string;
+      _type: "image";
+    };
+    caption?: string;
+    linkedProductMens?: {
+      _ref: string;
+      _type: "reference";
+      _weak?: boolean;
+      [internalGroqTypeReferenceTo]?: "product";
+    };
+    linkedProductWomens?: {
+      _ref: string;
+      _type: "reference";
+      _weak?: boolean;
+      [internalGroqTypeReferenceTo]?: "product";
+    };
+    _key: string;
+  }>;
+  curatedProducts?: Array<{
+    _ref: string;
+    _type: "reference";
+    _weak?: boolean;
+    _key: string;
+    [internalGroqTypeReferenceTo]?: "product";
+  }>;
+  store?: ShopifyCollection;
+  seo?: Seo;
+};
+
 export type Product = {
   _id: string;
   _type: "product";
@@ -1119,6 +1230,18 @@ export type Brand = {
       _type: "image";
     };
     caption?: string;
+    linkedProductMens?: {
+      _ref: string;
+      _type: "reference";
+      _weak?: boolean;
+      [internalGroqTypeReferenceTo]?: "product";
+    };
+    linkedProductWomens?: {
+      _ref: string;
+      _type: "reference";
+      _weak?: boolean;
+      [internalGroqTypeReferenceTo]?: "product";
+    };
     _key: string;
   }>;
   seo?: {
@@ -1169,105 +1292,6 @@ export type Category = {
     keywords?: Array<string>;
   };
   productCount?: number;
-};
-
-export type Collection = {
-  _id: string;
-  _type: "collection";
-  _createdAt: string;
-  _updatedAt: string;
-  _rev: string;
-  hidden?: string;
-  titleProxy?: ProxyString;
-  slugProxy?: ProxyString;
-  description?: string;
-  vector?: {
-    asset?: {
-      _ref: string;
-      _type: "reference";
-      _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-    };
-    media?: unknown;
-    hotspot?: SanityImageHotspot;
-    crop?: SanityImageCrop;
-    _type: "image";
-  };
-  showHero?: boolean;
-  hero?: Hero;
-  modules?: Array<{
-    asset?: {
-      _ref: string;
-      _type: "reference";
-      _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-    };
-    media?: unknown;
-    hotspot?: SanityImageHotspot;
-    crop?: SanityImageCrop;
-    _type: "image";
-    _key: string;
-  }>;
-  featured?: boolean;
-  sortOrder?: number;
-  isActive?: boolean;
-  menuImage?: {
-    asset?: {
-      _ref: string;
-      _type: "reference";
-      _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-    };
-    media?: unknown;
-    hotspot?: SanityImageHotspot;
-    crop?: SanityImageCrop;
-    alt?: string;
-    _type: "image";
-  };
-  gridLayout?: "4col" | "3col";
-  heroImage?: {
-    image?: {
-      asset?: {
-        _ref: string;
-        _type: "reference";
-        _weak?: boolean;
-        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-      };
-      media?: unknown;
-      hotspot?: SanityImageHotspot;
-      crop?: SanityImageCrop;
-      alt?: string;
-      _type: "image";
-    };
-    caption?: string;
-  };
-  productsPerImage?: 2 | 4 | 6 | 8;
-  editorialImages?: Array<{
-    image?: {
-      asset?: {
-        _ref: string;
-        _type: "reference";
-        _weak?: boolean;
-        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-      };
-      media?: unknown;
-      hotspot?: SanityImageHotspot;
-      crop?: SanityImageCrop;
-      alt?: string;
-      _type: "image";
-    };
-    caption?: string;
-    _key: string;
-  }>;
-  curatedProducts?: Array<{
-    _ref: string;
-    _type: "reference";
-    _weak?: boolean;
-    _key: string;
-    [internalGroqTypeReferenceTo]?: "product";
-  }>;
-  store?: ShopifyCollection;
-  seo?: Seo;
 };
 
 export type LinkExternal = {
@@ -1410,5 +1434,5 @@ export type Geopoint = {
   alt?: number;
 };
 
-export type AllSanitySchemaTypes = PortableTextSimple | PortableText | SiteSettings | HomepageVersion | Seo | Settings | NotFoundPage | FooterSettings | Menu | NavigationMenu | BlogProductsModule | PortableTextModule | ImageModule | SpotifyPlaylistsModule | EditorialModule | HeroModule | Spot | ShopifyProductVariant | ShopifyProduct | ShopifyCollection | ProxyString | ProductWithVariant | ProductVariant | Inventory | ProductReference | ProductHotspots | PriceRange | PlaceholderString | Option | SanityImageCrop | SanityImageHotspot | MenuLinks | ImageWithProductHotspots | Hero | CustomProductOptionSize | CustomProductOptionSizeObject | CustomProductOptionColor | CustomProductOptionColorObject | Color | CollectionRule | CollectionReference | CollectionLinks | CollectionGroup | LinkProduct | LinkInternal | Page | Slug | Home | BlogPost | BlogCategory | Product | Brand | Category | Collection | LinkExternal | LinkEmail | MediaTag | RgbaColor | HsvaColor | HslaColor | SanityImagePaletteSwatch | SanityImagePalette | SanityImageDimensions | SanityImageMetadata | SanityFileAsset | SanityAssetSourceData | SanityImageAsset | Geopoint;
+export type AllSanitySchemaTypes = PortableTextSimple | PortableText | SiteSettings | HomepageVersion | Seo | Settings | NotFoundPage | FooterSettings | Menu | NavigationMenu | BlogProductsModule | PortableTextModule | ImageModule | SpotifyPlaylistsModule | EditorialModule | HeroModule | Spot | ShopifyProductVariant | ShopifyProduct | ShopifyCollection | ProxyString | ProductWithVariant | ProductVariant | Inventory | ProductReference | ProductHotspots | PriceRange | PlaceholderString | Option | SanityImageCrop | SanityImageHotspot | MenuLinks | ImageWithProductHotspots | Hero | CustomProductOptionSize | CustomProductOptionSizeObject | CustomProductOptionColor | CustomProductOptionColorObject | Color | CollectionRule | CollectionReference | CollectionLinks | CollectionGroup | LinkProduct | LinkInternal | Page | Slug | Home | BlogPost | BlogCategory | Collection | Product | Brand | Category | LinkExternal | LinkEmail | MediaTag | RgbaColor | HsvaColor | HslaColor | SanityImagePaletteSwatch | SanityImagePalette | SanityImageDimensions | SanityImageMetadata | SanityFileAsset | SanityAssetSourceData | SanityImageAsset | Geopoint;
 export declare const internalGroqTypeReferenceTo: unique symbol;

--- a/schema.json
+++ b/schema.json
@@ -6515,6 +6515,697 @@
     }
   },
   {
+    "name": "collection",
+    "type": "document",
+    "attributes": {
+      "_id": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_type": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string",
+          "value": "collection"
+        }
+      },
+      "_createdAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_updatedAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_rev": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "hidden": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "titleProxy": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "proxyString"
+        },
+        "optional": true
+      },
+      "slugProxy": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "proxyString"
+        },
+        "optional": true
+      },
+      "description": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "vector": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "object",
+          "attributes": {
+            "asset": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "object",
+                "attributes": {
+                  "_ref": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "_type": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string",
+                      "value": "reference"
+                    }
+                  },
+                  "_weak": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "boolean"
+                    },
+                    "optional": true
+                  }
+                },
+                "dereferencesTo": "sanity.imageAsset"
+              },
+              "optional": true
+            },
+            "media": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "unknown"
+              },
+              "optional": true
+            },
+            "hotspot": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "inline",
+                "name": "sanity.imageHotspot"
+              },
+              "optional": true
+            },
+            "crop": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "inline",
+                "name": "sanity.imageCrop"
+              },
+              "optional": true
+            },
+            "_type": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string",
+                "value": "image"
+              }
+            }
+          }
+        },
+        "optional": true
+      },
+      "showHero": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "boolean"
+        },
+        "optional": true
+      },
+      "hero": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "hero"
+        },
+        "optional": true
+      },
+      "modules": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "array",
+          "of": {
+            "type": "object",
+            "attributes": {
+              "asset": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "object",
+                  "attributes": {
+                    "_ref": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "_type": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "string",
+                        "value": "reference"
+                      }
+                    },
+                    "_weak": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "boolean"
+                      },
+                      "optional": true
+                    }
+                  },
+                  "dereferencesTo": "sanity.imageAsset"
+                },
+                "optional": true
+              },
+              "media": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "unknown"
+                },
+                "optional": true
+              },
+              "hotspot": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "inline",
+                  "name": "sanity.imageHotspot"
+                },
+                "optional": true
+              },
+              "crop": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "inline",
+                  "name": "sanity.imageCrop"
+                },
+                "optional": true
+              },
+              "_type": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string",
+                  "value": "image"
+                }
+              }
+            },
+            "rest": {
+              "type": "object",
+              "attributes": {
+                "_key": {
+                  "type": "objectAttribute",
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "optional": true
+      },
+      "featured": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "boolean"
+        },
+        "optional": true
+      },
+      "sortOrder": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "number"
+        },
+        "optional": true
+      },
+      "isActive": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "boolean"
+        },
+        "optional": true
+      },
+      "menuImage": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "object",
+          "attributes": {
+            "asset": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "object",
+                "attributes": {
+                  "_ref": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "_type": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string",
+                      "value": "reference"
+                    }
+                  },
+                  "_weak": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "boolean"
+                    },
+                    "optional": true
+                  }
+                },
+                "dereferencesTo": "sanity.imageAsset"
+              },
+              "optional": true
+            },
+            "media": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "unknown"
+              },
+              "optional": true
+            },
+            "hotspot": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "inline",
+                "name": "sanity.imageHotspot"
+              },
+              "optional": true
+            },
+            "crop": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "inline",
+                "name": "sanity.imageCrop"
+              },
+              "optional": true
+            },
+            "alt": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string"
+              },
+              "optional": true
+            },
+            "_type": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string",
+                "value": "image"
+              }
+            }
+          }
+        },
+        "optional": true
+      },
+      "gridLayout": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "union",
+          "of": [
+            {
+              "type": "string",
+              "value": "4col"
+            },
+            {
+              "type": "string",
+              "value": "3col"
+            }
+          ]
+        },
+        "optional": true
+      },
+      "heroImage": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "object",
+          "attributes": {
+            "image": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "object",
+                "attributes": {
+                  "asset": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "object",
+                      "attributes": {
+                        "_ref": {
+                          "type": "objectAttribute",
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "_type": {
+                          "type": "objectAttribute",
+                          "value": {
+                            "type": "string",
+                            "value": "reference"
+                          }
+                        },
+                        "_weak": {
+                          "type": "objectAttribute",
+                          "value": {
+                            "type": "boolean"
+                          },
+                          "optional": true
+                        }
+                      },
+                      "dereferencesTo": "sanity.imageAsset"
+                    },
+                    "optional": true
+                  },
+                  "media": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "unknown"
+                    },
+                    "optional": true
+                  },
+                  "hotspot": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "inline",
+                      "name": "sanity.imageHotspot"
+                    },
+                    "optional": true
+                  },
+                  "crop": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "inline",
+                      "name": "sanity.imageCrop"
+                    },
+                    "optional": true
+                  },
+                  "alt": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    },
+                    "optional": true
+                  },
+                  "_type": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string",
+                      "value": "image"
+                    }
+                  }
+                }
+              },
+              "optional": true
+            },
+            "caption": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string"
+              },
+              "optional": true
+            }
+          }
+        },
+        "optional": true
+      },
+      "productsPerImage": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "union",
+          "of": [
+            {
+              "type": "number",
+              "value": 2
+            },
+            {
+              "type": "number",
+              "value": 4
+            },
+            {
+              "type": "number",
+              "value": 6
+            },
+            {
+              "type": "number",
+              "value": 8
+            }
+          ]
+        },
+        "optional": true
+      },
+      "editorialImages": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "array",
+          "of": {
+            "type": "object",
+            "attributes": {
+              "image": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "object",
+                  "attributes": {
+                    "asset": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "object",
+                        "attributes": {
+                          "_ref": {
+                            "type": "objectAttribute",
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "_type": {
+                            "type": "objectAttribute",
+                            "value": {
+                              "type": "string",
+                              "value": "reference"
+                            }
+                          },
+                          "_weak": {
+                            "type": "objectAttribute",
+                            "value": {
+                              "type": "boolean"
+                            },
+                            "optional": true
+                          }
+                        },
+                        "dereferencesTo": "sanity.imageAsset"
+                      },
+                      "optional": true
+                    },
+                    "media": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "unknown"
+                      },
+                      "optional": true
+                    },
+                    "hotspot": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "inline",
+                        "name": "sanity.imageHotspot"
+                      },
+                      "optional": true
+                    },
+                    "crop": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "inline",
+                        "name": "sanity.imageCrop"
+                      },
+                      "optional": true
+                    },
+                    "alt": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "string"
+                      },
+                      "optional": true
+                    },
+                    "_type": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "string",
+                        "value": "image"
+                      }
+                    }
+                  }
+                },
+                "optional": true
+              },
+              "caption": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string"
+                },
+                "optional": true
+              },
+              "linkedProductMens": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "object",
+                  "attributes": {
+                    "_ref": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "_type": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "string",
+                        "value": "reference"
+                      }
+                    },
+                    "_weak": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "boolean"
+                      },
+                      "optional": true
+                    }
+                  },
+                  "dereferencesTo": "product"
+                },
+                "optional": true
+              },
+              "linkedProductWomens": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "object",
+                  "attributes": {
+                    "_ref": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "_type": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "string",
+                        "value": "reference"
+                      }
+                    },
+                    "_weak": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "boolean"
+                      },
+                      "optional": true
+                    }
+                  },
+                  "dereferencesTo": "product"
+                },
+                "optional": true
+              }
+            },
+            "rest": {
+              "type": "object",
+              "attributes": {
+                "_key": {
+                  "type": "objectAttribute",
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "optional": true
+      },
+      "curatedProducts": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "array",
+          "of": {
+            "type": "object",
+            "attributes": {
+              "_ref": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string"
+                }
+              },
+              "_type": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string",
+                  "value": "reference"
+                }
+              },
+              "_weak": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "boolean"
+                },
+                "optional": true
+              }
+            },
+            "dereferencesTo": "product",
+            "rest": {
+              "type": "object",
+              "attributes": {
+                "_key": {
+                  "type": "objectAttribute",
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "optional": true
+      },
+      "store": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "shopifyCollection"
+        },
+        "optional": true
+      },
+      "seo": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "seo"
+        },
+        "optional": true
+      }
+    }
+  },
+  {
     "name": "product",
     "type": "document",
     "attributes": {
@@ -7367,6 +8058,66 @@
                   "type": "string"
                 },
                 "optional": true
+              },
+              "linkedProductMens": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "object",
+                  "attributes": {
+                    "_ref": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "_type": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "string",
+                        "value": "reference"
+                      }
+                    },
+                    "_weak": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "boolean"
+                      },
+                      "optional": true
+                    }
+                  },
+                  "dereferencesTo": "product"
+                },
+                "optional": true
+              },
+              "linkedProductWomens": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "object",
+                  "attributes": {
+                    "_ref": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "_type": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "string",
+                        "value": "reference"
+                      }
+                    },
+                    "_weak": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "boolean"
+                      },
+                      "optional": true
+                    }
+                  },
+                  "dereferencesTo": "product"
+                },
+                "optional": true
               }
             },
             "rest": {
@@ -7674,637 +8425,6 @@
         "type": "objectAttribute",
         "value": {
           "type": "number"
-        },
-        "optional": true
-      }
-    }
-  },
-  {
-    "name": "collection",
-    "type": "document",
-    "attributes": {
-      "_id": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_type": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string",
-          "value": "collection"
-        }
-      },
-      "_createdAt": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_updatedAt": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_rev": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "hidden": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "titleProxy": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "inline",
-          "name": "proxyString"
-        },
-        "optional": true
-      },
-      "slugProxy": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "inline",
-          "name": "proxyString"
-        },
-        "optional": true
-      },
-      "description": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "vector": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "object",
-          "attributes": {
-            "asset": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "object",
-                "attributes": {
-                  "_ref": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "string"
-                    }
-                  },
-                  "_type": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "string",
-                      "value": "reference"
-                    }
-                  },
-                  "_weak": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "boolean"
-                    },
-                    "optional": true
-                  }
-                },
-                "dereferencesTo": "sanity.imageAsset"
-              },
-              "optional": true
-            },
-            "media": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "unknown"
-              },
-              "optional": true
-            },
-            "hotspot": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "inline",
-                "name": "sanity.imageHotspot"
-              },
-              "optional": true
-            },
-            "crop": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "inline",
-                "name": "sanity.imageCrop"
-              },
-              "optional": true
-            },
-            "_type": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "string",
-                "value": "image"
-              }
-            }
-          }
-        },
-        "optional": true
-      },
-      "showHero": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "boolean"
-        },
-        "optional": true
-      },
-      "hero": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "inline",
-          "name": "hero"
-        },
-        "optional": true
-      },
-      "modules": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "array",
-          "of": {
-            "type": "object",
-            "attributes": {
-              "asset": {
-                "type": "objectAttribute",
-                "value": {
-                  "type": "object",
-                  "attributes": {
-                    "_ref": {
-                      "type": "objectAttribute",
-                      "value": {
-                        "type": "string"
-                      }
-                    },
-                    "_type": {
-                      "type": "objectAttribute",
-                      "value": {
-                        "type": "string",
-                        "value": "reference"
-                      }
-                    },
-                    "_weak": {
-                      "type": "objectAttribute",
-                      "value": {
-                        "type": "boolean"
-                      },
-                      "optional": true
-                    }
-                  },
-                  "dereferencesTo": "sanity.imageAsset"
-                },
-                "optional": true
-              },
-              "media": {
-                "type": "objectAttribute",
-                "value": {
-                  "type": "unknown"
-                },
-                "optional": true
-              },
-              "hotspot": {
-                "type": "objectAttribute",
-                "value": {
-                  "type": "inline",
-                  "name": "sanity.imageHotspot"
-                },
-                "optional": true
-              },
-              "crop": {
-                "type": "objectAttribute",
-                "value": {
-                  "type": "inline",
-                  "name": "sanity.imageCrop"
-                },
-                "optional": true
-              },
-              "_type": {
-                "type": "objectAttribute",
-                "value": {
-                  "type": "string",
-                  "value": "image"
-                }
-              }
-            },
-            "rest": {
-              "type": "object",
-              "attributes": {
-                "_key": {
-                  "type": "objectAttribute",
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "optional": true
-      },
-      "featured": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "boolean"
-        },
-        "optional": true
-      },
-      "sortOrder": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "number"
-        },
-        "optional": true
-      },
-      "isActive": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "boolean"
-        },
-        "optional": true
-      },
-      "menuImage": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "object",
-          "attributes": {
-            "asset": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "object",
-                "attributes": {
-                  "_ref": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "string"
-                    }
-                  },
-                  "_type": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "string",
-                      "value": "reference"
-                    }
-                  },
-                  "_weak": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "boolean"
-                    },
-                    "optional": true
-                  }
-                },
-                "dereferencesTo": "sanity.imageAsset"
-              },
-              "optional": true
-            },
-            "media": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "unknown"
-              },
-              "optional": true
-            },
-            "hotspot": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "inline",
-                "name": "sanity.imageHotspot"
-              },
-              "optional": true
-            },
-            "crop": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "inline",
-                "name": "sanity.imageCrop"
-              },
-              "optional": true
-            },
-            "alt": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "string"
-              },
-              "optional": true
-            },
-            "_type": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "string",
-                "value": "image"
-              }
-            }
-          }
-        },
-        "optional": true
-      },
-      "gridLayout": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "union",
-          "of": [
-            {
-              "type": "string",
-              "value": "4col"
-            },
-            {
-              "type": "string",
-              "value": "3col"
-            }
-          ]
-        },
-        "optional": true
-      },
-      "heroImage": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "object",
-          "attributes": {
-            "image": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "object",
-                "attributes": {
-                  "asset": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "object",
-                      "attributes": {
-                        "_ref": {
-                          "type": "objectAttribute",
-                          "value": {
-                            "type": "string"
-                          }
-                        },
-                        "_type": {
-                          "type": "objectAttribute",
-                          "value": {
-                            "type": "string",
-                            "value": "reference"
-                          }
-                        },
-                        "_weak": {
-                          "type": "objectAttribute",
-                          "value": {
-                            "type": "boolean"
-                          },
-                          "optional": true
-                        }
-                      },
-                      "dereferencesTo": "sanity.imageAsset"
-                    },
-                    "optional": true
-                  },
-                  "media": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "unknown"
-                    },
-                    "optional": true
-                  },
-                  "hotspot": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "inline",
-                      "name": "sanity.imageHotspot"
-                    },
-                    "optional": true
-                  },
-                  "crop": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "inline",
-                      "name": "sanity.imageCrop"
-                    },
-                    "optional": true
-                  },
-                  "alt": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "string"
-                    },
-                    "optional": true
-                  },
-                  "_type": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "string",
-                      "value": "image"
-                    }
-                  }
-                }
-              },
-              "optional": true
-            },
-            "caption": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "string"
-              },
-              "optional": true
-            }
-          }
-        },
-        "optional": true
-      },
-      "productsPerImage": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "union",
-          "of": [
-            {
-              "type": "number",
-              "value": 2
-            },
-            {
-              "type": "number",
-              "value": 4
-            },
-            {
-              "type": "number",
-              "value": 6
-            },
-            {
-              "type": "number",
-              "value": 8
-            }
-          ]
-        },
-        "optional": true
-      },
-      "editorialImages": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "array",
-          "of": {
-            "type": "object",
-            "attributes": {
-              "image": {
-                "type": "objectAttribute",
-                "value": {
-                  "type": "object",
-                  "attributes": {
-                    "asset": {
-                      "type": "objectAttribute",
-                      "value": {
-                        "type": "object",
-                        "attributes": {
-                          "_ref": {
-                            "type": "objectAttribute",
-                            "value": {
-                              "type": "string"
-                            }
-                          },
-                          "_type": {
-                            "type": "objectAttribute",
-                            "value": {
-                              "type": "string",
-                              "value": "reference"
-                            }
-                          },
-                          "_weak": {
-                            "type": "objectAttribute",
-                            "value": {
-                              "type": "boolean"
-                            },
-                            "optional": true
-                          }
-                        },
-                        "dereferencesTo": "sanity.imageAsset"
-                      },
-                      "optional": true
-                    },
-                    "media": {
-                      "type": "objectAttribute",
-                      "value": {
-                        "type": "unknown"
-                      },
-                      "optional": true
-                    },
-                    "hotspot": {
-                      "type": "objectAttribute",
-                      "value": {
-                        "type": "inline",
-                        "name": "sanity.imageHotspot"
-                      },
-                      "optional": true
-                    },
-                    "crop": {
-                      "type": "objectAttribute",
-                      "value": {
-                        "type": "inline",
-                        "name": "sanity.imageCrop"
-                      },
-                      "optional": true
-                    },
-                    "alt": {
-                      "type": "objectAttribute",
-                      "value": {
-                        "type": "string"
-                      },
-                      "optional": true
-                    },
-                    "_type": {
-                      "type": "objectAttribute",
-                      "value": {
-                        "type": "string",
-                        "value": "image"
-                      }
-                    }
-                  }
-                },
-                "optional": true
-              },
-              "caption": {
-                "type": "objectAttribute",
-                "value": {
-                  "type": "string"
-                },
-                "optional": true
-              }
-            },
-            "rest": {
-              "type": "object",
-              "attributes": {
-                "_key": {
-                  "type": "objectAttribute",
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "optional": true
-      },
-      "curatedProducts": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "array",
-          "of": {
-            "type": "object",
-            "attributes": {
-              "_ref": {
-                "type": "objectAttribute",
-                "value": {
-                  "type": "string"
-                }
-              },
-              "_type": {
-                "type": "objectAttribute",
-                "value": {
-                  "type": "string",
-                  "value": "reference"
-                }
-              },
-              "_weak": {
-                "type": "objectAttribute",
-                "value": {
-                  "type": "boolean"
-                },
-                "optional": true
-              }
-            },
-            "dereferencesTo": "product",
-            "rest": {
-              "type": "object",
-              "attributes": {
-                "_key": {
-                  "type": "objectAttribute",
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "optional": true
-      },
-      "store": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "inline",
-          "name": "shopifyCollection"
-        },
-        "optional": true
-      },
-      "seo": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "inline",
-          "name": "seo"
         },
         "optional": true
       }

--- a/src/app/[locale]/(main)/products/[handle]/page.tsx
+++ b/src/app/[locale]/(main)/products/[handle]/page.tsx
@@ -127,9 +127,7 @@ export default async function ProductPage({
           colorVariants={product.colorVariants}
           currentProductId={product._id}
         />
-        <Suspense fallback={null}>
-          <ProductEditorialImages editorialImages={product.editorialImages} />
-        </Suspense>
+        <ProductEditorialImages editorialImages={product.editorialImages} />
       </div>
       {product.brand?.slug && (
         <Suspense fallback={null}>

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -1,4 +1,4 @@
-import { revalidatePath } from "next/cache";
+import { revalidatePath, revalidateTag } from "next/cache";
 import { NextRequest, NextResponse } from "next/server";
 import { SUPPORTED_LOCALES } from "@/lib/locale/localeUtils";
 
@@ -70,6 +70,13 @@ export async function POST(request: NextRequest) {
       if (slug) {
         revalidateForAllLocales(`/brands/${slug}`, revalidated);
       }
+    }
+
+    // Bust cached header data when relevant content types change
+    const HEADER_CONTENT_TYPES = ["brand", "navigationMenu", "category", "blogPost", "collection"];
+    if (HEADER_CONTENT_TYPES.includes(body._type)) {
+      revalidateTag("header-data", "max");
+      revalidated.push("tag:header-data");
     }
 
     // Structured log for Vercel Functions monitoring

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -52,15 +52,6 @@ body {
   }
 }
 
-/* Prevent body scroll when modal is open */
-body.modal-open {
-  overflow: hidden !important;
-  position: fixed;
-  width: 100%;
-  height: 100%;
-  top: 0;
-  left: 0;
-}
 
 @layer components {
   /* Consistent vertical spacing between homepage/page sections */

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -50,7 +50,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         `*[_type == "blogPost"]{ "slug": slug.current, "category": category->slug.current, publishedAt }`
       ),
       client.fetch<CategoryPathEntry[]>(
-        `*[_type == "product" && !store.isDeleted && defined(gender) && defined(category)]{
+        `*[_type == "product" && !store.isDeleted && defined(gender) && defined(category) && gender in ["mens", "womens"]]{
           gender,
           "mainCategory": select(
             category->categoryType == "main" => category->slug.current,
@@ -76,7 +76,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { path: "", changeFrequency: "daily", priority: 1 },
     { path: "/mens", changeFrequency: "daily", priority: 0.9 },
     { path: "/womens", changeFrequency: "daily", priority: 0.9 },
-    { path: "/unisex", changeFrequency: "daily", priority: 0.8 },
     { path: "/collections", changeFrequency: "weekly", priority: 0.8 },
     { path: "/brands", changeFrequency: "weekly", priority: 0.8 },
     { path: "/blog", changeFrequency: "weekly", priority: 0.7 },
@@ -85,6 +84,8 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   // Category paths - extract unique from products
   const categoryPathsSet = new Set<string>();
   for (const item of categoryPaths) {
+    // Only generate paths for genders that have routes (mens, womens)
+    if (item.gender !== "mens" && item.gender !== "womens") continue;
     if (item.gender && item.mainCategory && item.subcategory && item.specific) {
       categoryPathsSet.add(
         `/${item.gender}/${item.mainCategory}/${item.subcategory}/${item.specific}`

--- a/src/components/HeaderServer.tsx
+++ b/src/components/HeaderServer.tsx
@@ -1,16 +1,9 @@
-import { getAllBrands, getMenu } from "@/sanity/lib/getData";
-import { getFullMenuData } from "@/sanity/lib/getCategories";
-import { getBlogPosts } from "@/sanity/lib/getBlog";
+import { getCachedHeaderData } from "@/sanity/lib/getHeaderData";
 import Header from "./Header";
 
 export default async function HeaderServer() {
-  // Fetch all header data in parallel (4 queries total instead of 20+)
-  const [menuData, brands, menuConfig, blogPosts] = await Promise.all([
-    getFullMenuData(), // 2 queries: one per gender, fetches full category hierarchy
-    getAllBrands(),
-    getMenu(),
-    getBlogPosts(10),
-  ]);
+  const { menuData, brands, menuConfig, blogPosts } =
+    await getCachedHeaderData();
 
   if (!menuConfig) {
     console.warn("No menu configuration found");

--- a/src/components/ProductGridWithImages.tsx
+++ b/src/components/ProductGridWithImages.tsx
@@ -15,6 +15,8 @@ export type EditorialImage = {
     alt?: string;
   };
   caption?: string;
+  linkedProductHandleMens?: string;
+  linkedProductHandleWomens?: string;
 };
 
 const EMPTY_EDITORIAL_IMAGES: EditorialImage[] = [];
@@ -27,6 +29,8 @@ interface ProductGridWithImagesProps {
   gridLayout?: "4col" | "3col";
   /** Whether more products exist beyond what's shown (guards editorial image boundary) */
   hasMore?: boolean;
+  /** Active gender filter — determines which product link to use on editorial images */
+  activeGender?: string;
 }
 
 type GridItem = {
@@ -111,19 +115,30 @@ function ProductItem({
   );
 }
 
+// Resolve editorial image product link based on active gender filter
+function getEditorialProductHandle(
+  image: EditorialImage,
+  activeGender?: string
+): string | undefined {
+  if (activeGender === "mens") return image.linkedProductHandleMens;
+  if (activeGender === "womens") return image.linkedProductHandleWomens;
+  // No gender filter: prefer mens, fallback to womens
+  return image.linkedProductHandleMens || image.linkedProductHandleWomens;
+}
+
 // Render an editorial image
 function EditorialImageBlock({
   image,
-  idx,
   isMobile,
   gridLayout = "4col",
   imageIndex = 0,
+  activeGender,
 }: {
   image: EditorialImage;
-  idx: number;
   isMobile: boolean;
   gridLayout?: "4col" | "3col";
   imageIndex?: number;
+  activeGender?: string;
 }) {
   const imageUrl = image.image?.asset?.url;
   if (!imageUrl) return null;
@@ -148,11 +163,8 @@ function EditorialImageBlock({
     return isRightAligned ? `${baseClass} col-start-3` : baseClass;
   };
 
-  return (
-    <div
-      key={`${image._key || idx}-${isMobile ? "mobile" : "xl"}`}
-      className={getClassName()}
-    >
+  const content = (
+    <>
       <Image
         src={urlFor(image.image).url()}
         alt={image.image.alt || image.caption || "Editorial image"}
@@ -165,6 +177,25 @@ function EditorialImageBlock({
           {image.caption}
         </div>
       )}
+    </>
+  );
+
+  const linkedHandle = getEditorialProductHandle(image, activeGender);
+
+  if (linkedHandle) {
+    return (
+      <LocaleLink
+        href={`/products/${linkedHandle}`}
+        className={getClassName()}
+      >
+        {content}
+      </LocaleLink>
+    );
+  }
+
+  return (
+    <div className={getClassName()}>
+      {content}
     </div>
   );
 }
@@ -175,11 +206,13 @@ function GridContent({
   isMobile,
   gridLayout = "4col",
   sizes,
+  activeGender,
 }: {
   gridItems: GridItem[];
   isMobile: boolean;
   gridLayout?: "4col" | "3col";
   sizes?: string;
+  activeGender?: string;
 }) {
   return (
     <>
@@ -200,10 +233,10 @@ function GridContent({
             <EditorialImageBlock
               key={`${item.image._key || idx}`}
               image={item.image}
-              idx={idx}
               isMobile={isMobile}
               gridLayout={gridLayout}
               imageIndex={item.imageIndex}
+              activeGender={activeGender}
             />
           );
         }
@@ -221,6 +254,7 @@ export default function ProductGridWithImages({
   productsPerImageXL = 8,
   gridLayout = "4col",
   hasMore = false,
+  activeGender,
 }: ProductGridWithImagesProps) {
   // Determine XL grid columns based on layout
   const xlGridCols =
@@ -269,6 +303,7 @@ export default function ProductGridWithImages({
           isMobile={true}
           gridLayout={gridLayout}
           sizes={productSizes}
+          activeGender={activeGender}
         />
       </div>
 
@@ -279,6 +314,7 @@ export default function ProductGridWithImages({
           isMobile={false}
           gridLayout={gridLayout}
           sizes={productSizes}
+          activeGender={activeGender}
         />
       </div>
     </div>

--- a/src/components/ScrollRestoration.tsx
+++ b/src/components/ScrollRestoration.tsx
@@ -13,7 +13,7 @@ export function ScrollRestoration() {
     document.body.style.width = "";
     document.body.style.left = "";
     document.body.style.right = "";
-    document.body.classList.remove("modal-open");
+
   }, []);
 
   // Scroll to top on route change

--- a/src/components/homepage/ContentModule.tsx
+++ b/src/components/homepage/ContentModule.tsx
@@ -64,14 +64,16 @@ function MediaContent({ module }: { module: PortableTextModule }) {
 
     return (
       <div className="flex justify-center relative overflow-hidden w-full">
-        <video
-          src={video.asset.url}
-          className="w-full xl:w-[30vw] object-cover"
-          autoPlay
-          muted
-          loop
-          playsInline
-        />
+        <div className="w-full xl:w-[30vw] aspect-[4/5] relative bg-gray-100">
+          <video
+            src={video.asset.url}
+            className="absolute inset-0 w-full h-full object-cover"
+            autoPlay
+            muted
+            loop
+            playsInline
+          />
+        </div>
       </div>
     );
   }
@@ -90,16 +92,17 @@ function MediaContent({ module }: { module: PortableTextModule }) {
 
     return (
       <div className="flex justify-center relative overflow-hidden w-full">
-        <Image
-          src={imageWithLqip.asset?.url || ""}
-          alt={module.image.alt || module.title || "Content image"}
-          width={800}
-          height={1000}
-          className="w-full xl:w-[30vw] h-auto object-cover"
-          style={{ objectPosition }}
-          sizes="30vw"
-          {...getBlurProps(imageWithLqip)}
-        />
+        <div className="w-full xl:w-[30vw] aspect-[4/5] relative">
+          <Image
+            src={imageWithLqip.asset?.url || ""}
+            alt={module.image.alt || module.title || "Content image"}
+            fill
+            className="object-cover"
+            style={{ objectPosition }}
+            sizes="(min-width: 1280px) 30vw, 100vw"
+            {...getBlurProps(imageWithLqip)}
+          />
+        </div>
       </div>
     );
   }

--- a/src/components/menumodal/GenderMenuContent.tsx
+++ b/src/components/menumodal/GenderMenuContent.tsx
@@ -222,12 +222,12 @@ function GenderMenuContent({
       {/* Collections Section */}
       {featuredCollections && featuredCollections.length > 0 && (
         <div>
-          <div className="px-2 mt-4">
-            <span className="text-xs">Featured Collections</span>
+          <div className="mt-4">
+            <span className="text-xs px-2">Featured Collections</span>
 
             {/* Collection carousel */}
-            <div className="mt-2 overflow-x-auto snap-x snap-mandatory scrollbar-hide -mx-2 px-2">
-              <div className="flex gap-2">
+            <div className="mt-2 overflow-x-auto snap-x snap-mandatory scrollbar-hide scroll-px-2">
+              <div className="flex gap-2 px-2">
                 {featuredCollections.map((collection: CollectionMenuItem) => {
                   if (!collection?.slug?.current) return null;
                   return (

--- a/src/components/plp/ProductListing.tsx
+++ b/src/components/plp/ProductListing.tsx
@@ -152,6 +152,7 @@ function ProductListingInner({
           productsPerImageXL={productsPerImageXL}
           gridLayout={gridLayout}
           hasMore={remainingCount > 0}
+          activeGender={filters.gender.length === 1 ? filters.gender[0] : undefined}
         />
       ) : (
         <ProductGrid

--- a/src/sanity/lib/getBrands.ts
+++ b/src/sanity/lib/getBrands.ts
@@ -70,7 +70,9 @@ export const getBrandBySlug = cache(async (slug: string) => {
         },
         alt
       },
-      caption
+      caption,
+      "linkedProductHandleMens": coalesce(linkedProductMens->shopifyHandle, linkedProductMens->store.slug.current),
+      "linkedProductHandleWomens": coalesce(linkedProductWomens->shopifyHandle, linkedProductWomens->store.slug.current)
     }
   }`;
 

--- a/src/sanity/lib/getData.ts
+++ b/src/sanity/lib/getData.ts
@@ -37,4 +37,6 @@ export { getHomepage } from "./getHomepage";
 
 export { getMenu } from "./getMenu";
 
+export { getCachedHeaderData } from "./getHeaderData";
+
 export { getSiteSettings } from "./getSiteSettings";

--- a/src/sanity/lib/getHeaderData.ts
+++ b/src/sanity/lib/getHeaderData.ts
@@ -1,0 +1,137 @@
+import { unstable_cache } from "next/cache";
+import { client } from "./client";
+import type {
+  MenuData,
+  MenuConfig,
+  BrandMenuItem,
+  BlogPostMenuItem,
+  SubcategoryMenuItem,
+} from "@/types/menu";
+
+// CDN client for published header data — faster on cold cache
+const cdnClient = client.withConfig({ useCdn: true });
+
+// Result shape from the unified GROQ query
+interface RawHeaderQueryResult {
+  categories: Array<{
+    _id: string;
+    title: string;
+    slug: { current: string };
+    subcategories: SubcategoryMenuItem[];
+  }>;
+  navigationMenu: MenuConfig | null;
+  brands: BrandMenuItem[];
+  blogPosts: BlogPostMenuItem[];
+}
+
+// Target shape matching Header component props
+interface HeaderData {
+  menuData: MenuData;
+  brands: BrandMenuItem[];
+  menuConfig: MenuConfig | undefined;
+  blogPosts: BlogPostMenuItem[];
+}
+
+const HEADER_QUERY = `{
+  "categories": *[_type == "category" && categoryType == "main"] | order(sortOrder asc, title asc) {
+    _id,
+    title,
+    slug { current },
+    "subcategories": *[_type == "category" && categoryType == "subcategory" && parentCategory._ref == ^._id] | order(title asc) {
+      _id,
+      title,
+      slug { current },
+      categoryType,
+      "parentCategory": { "title": ^.title, "slug": ^.slug },
+      "subSubcategories": *[_type == "category" && categoryType == "specific" && parentCategory._ref == ^._id] | order(sortOrder asc, title asc) {
+        _id,
+        title,
+        slug { current },
+        description,
+        sortOrder,
+        "parentCategory": { "_id": ^._id, "title": ^.title, "slug": ^.slug }
+      }
+    }
+  },
+  "navigationMenu": *[_type == "navigationMenu"][0] {
+    men {
+      featuredCollections[]-> {
+        _id,
+        "title": store.title,
+        "slug": store.slug { current },
+        menuImage { asset-> { _id, url }, alt }
+      }
+    },
+    women {
+      featuredCollections[]-> {
+        _id,
+        "title": store.title,
+        "slug": store.slug { current },
+        menuImage { asset-> { _id, url }, alt }
+      }
+    },
+    help { links[] { label, url, _key } },
+    "ourSpace": ourSpace { links[] { label, url, _key } }
+  },
+  "brands": *[_type == "brand"] | order(name asc) {
+    _id,
+    name,
+    slug { current },
+    logo { asset-> { url } },
+    featured
+  },
+  "blogPosts": *[_type == "blogPost"] | order(publishedAt desc) [0...10] {
+    _id,
+    title,
+    slug { current },
+    category-> { title, slug { current } },
+    featuredImage { asset-> { url, "lqip": metadata.lqip }, alt }
+  }
+}`;
+
+function transformCategoryArray(
+  categories: RawHeaderQueryResult["categories"]
+): { [slug: string]: SubcategoryMenuItem[] } {
+  const result: Record<string, SubcategoryMenuItem[]> = {};
+  for (const cat of categories || []) {
+    if (cat.slug?.current) {
+      result[cat.slug.current] = cat.subcategories || [];
+    }
+  }
+  return result;
+}
+
+const EMPTY_HEADER: HeaderData = {
+  menuData: { men: {}, women: {} },
+  brands: [],
+  menuConfig: undefined,
+  blogPosts: [],
+};
+
+/**
+ * Cached header data — single GROQ query, cached via unstable_cache.
+ * Uses client.fetch (NOT sanityFetch from defineLive) to avoid dual-cache conflict.
+ * Revalidated on-demand via revalidateTag("header-data") from the revalidation webhook.
+ *
+ * Content types that trigger revalidation: brand, navigationMenu, category, blogPost, collection.
+ * If a new content type affects the header, add it to HEADER_CONTENT_TYPES in /api/revalidate/route.ts.
+ */
+export const getCachedHeaderData = unstable_cache(
+  async (): Promise<HeaderData> => {
+    try {
+      const data = await cdnClient.fetch<RawHeaderQueryResult>(HEADER_QUERY);
+      const categoryMap = transformCategoryArray(data.categories);
+      return {
+        menuData: { men: categoryMap, women: categoryMap },
+        brands: data.brands ?? [],
+        menuConfig: data.navigationMenu ?? undefined,
+        blogPosts: data.blogPosts ?? [],
+      };
+    } catch (error) {
+      console.error("Failed to fetch header data:", error);
+      return EMPTY_HEADER;
+    }
+  },
+  ["header-data"],
+  { tags: ["header-data"] }
+);

--- a/src/sanity/lib/groqUtils.ts
+++ b/src/sanity/lib/groqUtils.ts
@@ -276,7 +276,9 @@ export const EDITORIAL_IMAGES_PROJECTION = `editorialImages[] {
     },
     alt
   },
-  caption
+  caption,
+  "linkedProductHandleMens": coalesce(linkedProductMens->shopifyHandle, linkedProductMens->store.slug.current),
+  "linkedProductHandleWomens": coalesce(linkedProductWomens->shopifyHandle, linkedProductWomens->store.slug.current)
 }`;
 
 /**

--- a/src/sanity/schemaTypes/brand.ts
+++ b/src/sanity/schemaTypes/brand.ts
@@ -131,17 +131,40 @@ export default defineType({
               type: "string",
               description: "Optional caption text for the image",
             }),
+            defineField({
+              name: "linkedProductMens",
+              title: "Link to Product (Men's)",
+              type: "reference",
+              to: [{ type: "product" }],
+              description:
+                "Optional: links to this product when viewing men's products",
+            }),
+            defineField({
+              name: "linkedProductWomens",
+              title: "Link to Product (Women's)",
+              type: "reference",
+              to: [{ type: "product" }],
+              description:
+                "Optional: links to this product when viewing women's products",
+            }),
           ],
           preview: {
             select: {
               title: "caption",
               media: "image",
-              position: "position",
+              mensTitle: "linkedProductMens.store.title",
+              womensTitle: "linkedProductWomens.store.title",
             },
-            prepare({ title, media }) {
+            prepare({ title, media, mensTitle, womensTitle }) {
+              const links = [
+                mensTitle && `M: ${mensTitle}`,
+                womensTitle && `W: ${womensTitle}`,
+              ]
+                .filter(Boolean)
+                .join(" | ");
               return {
                 title: title || "Editorial Image",
-                subtitle: "Appears after every 6 products",
+                subtitle: links || "No links",
                 media,
               };
             },

--- a/src/sanity/schemaTypes/documents/collection.tsx
+++ b/src/sanity/schemaTypes/documents/collection.tsx
@@ -227,17 +227,40 @@ export const collectionType = defineType({
               type: "string",
               description: "Optional caption text for the image",
             }),
+            defineField({
+              name: "linkedProductMens",
+              title: "Link to Product (Men's)",
+              type: "reference",
+              to: [{ type: "product" }],
+              description:
+                "Optional: links to this product when viewing men's products",
+            }),
+            defineField({
+              name: "linkedProductWomens",
+              title: "Link to Product (Women's)",
+              type: "reference",
+              to: [{ type: "product" }],
+              description:
+                "Optional: links to this product when viewing women's products",
+            }),
           ],
           preview: {
             select: {
               title: "caption",
               media: "image",
-              position: "position",
+              mensTitle: "linkedProductMens.store.title",
+              womensTitle: "linkedProductWomens.store.title",
             },
-            prepare({ title, media }) {
+            prepare({ title, media, mensTitle, womensTitle }) {
+              const links = [
+                mensTitle && `M: ${mensTitle}`,
+                womensTitle && `W: ${womensTitle}`,
+              ]
+                .filter(Boolean)
+                .join(" | ");
               return {
                 title: title || "Editorial Image",
-                subtitle: "Appears after every 2 products",
+                subtitle: links || "No links",
                 media,
               };
             },


### PR DESCRIPTION
## Summary

- **Gender-aware editorial image links** (#166): Editorial images on PLPs can now link to product pages with separate men's/women's references, resolving based on active gender filter
- **Header data caching + unified GROQ** (#163): Cached header queries with `React.cache()`, unified GROQ projection, fixed sitemap 404s
- **CLS fixes** (#164): Fixed layout shifts on ContentModule media and PDP editorial images
- **Dead code cleanup**: Removed unused `.modal-open` CSS and `classList` reference
- **Mobile menu scroll padding** (#166): Fixed Featured Collections carousel edge bleeding with `scroll-px-2`

### Files changed: 19 files, 1 new file (`getHeaderData.ts`)

## Test plan
- [x] Editorial images link to correct PDP based on gender filter
- [x] Header loads correctly with cached data
- [x] Sitemap returns valid URLs (no 404s)
- [x] No CLS on ContentModule media sections
- [x] Mobile menu Featured Collections has edge padding
- [x] `bun build` passes