### PR TITLE
refactor: remove unused Sanity schema fields

### DIFF
--- a/sanity.types.ts
+++ b/sanity.types.ts
@@ -1100,7 +1100,6 @@ export type Product = {
   hidden?: string;
   titleProxy?: ProxyString;
   slugProxy?: ProxyString;
-  body?: PortableText;
   store?: ShopifyProduct;
   seo?: Seo;
   category?: {
@@ -1279,11 +1278,6 @@ export type Category = {
     [internalGroqTypeReferenceTo]?: "category";
   };
   categoryType?: "main" | "subcategory" | "specific";
-  level?: number;
-  visibility?: {
-    navigation?: boolean;
-    filters?: boolean;
-  };
   featured?: boolean;
   sortOrder?: number;
   seo?: {
@@ -1291,7 +1285,6 @@ export type Category = {
     description?: string;
     keywords?: Array<string>;
   };
-  productCount?: number;
 };
 
 export type LinkExternal = {

--- a/schema.json
+++ b/schema.json
@@ -7263,14 +7263,6 @@
         },
         "optional": true
       },
-      "body": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "inline",
-          "name": "portableText"
-        },
-        "optional": true
-      },
       "store": {
         "type": "objectAttribute",
         "value": {
@@ -8344,36 +8336,6 @@
         },
         "optional": true
       },
-      "level": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "number"
-        },
-        "optional": true
-      },
-      "visibility": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "object",
-          "attributes": {
-            "navigation": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "boolean"
-              },
-              "optional": true
-            },
-            "filters": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "boolean"
-              },
-              "optional": true
-            }
-          }
-        },
-        "optional": true
-      },
       "featured": {
         "type": "objectAttribute",
         "value": {
@@ -8418,13 +8380,6 @@
               "optional": true
             }
           }
-        },
-        "optional": true
-      },
-      "productCount": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "number"
         },
         "optional": true
       }

--- a/src/sanity/schemaTypes/category.ts
+++ b/src/sanity/schemaTypes/category.ts
@@ -8,20 +8,15 @@ export default defineType({
     select: {
       title: "title",
       media: "image",
-      productCount: "productCount",
       categoryType: "categoryType",
       parentCategory: "parentCategory.title",
     },
-    prepare({ title, media, productCount, categoryType, parentCategory }) {
+    prepare({ title, media, categoryType, parentCategory }) {
       const typeLabel = categoryType ? `[${categoryType}]` : "";
       const parentLabel = parentCategory ? ` → ${parentCategory}` : "";
-      const countLabel = productCount
-        ? `${productCount} products`
-        : "No products";
 
       return {
         title: `${title}${typeLabel}${parentLabel}`,
-        subtitle: countLabel,
         media,
       };
     },
@@ -96,37 +91,6 @@ export default defineType({
     }),
 
     defineField({
-      name: "level",
-      title: "Hierarchy Level",
-      type: "number",
-      readOnly: true,
-      description:
-        "Automatically calculated: 1=main, 2=subcategory, 3=specific",
-    }),
-
-    defineField({
-      name: "visibility",
-      title: "Visibility",
-      type: "object",
-      fields: [
-        {
-          name: "navigation",
-          type: "boolean",
-          title: "Show in Navigation",
-          initialValue: true,
-          description: "Show this category in the main menu",
-        },
-        {
-          name: "filters",
-          type: "boolean",
-          title: "Show in Filters",
-          initialValue: true,
-          description: "Show this category in product filters",
-        },
-      ],
-    }),
-
-    defineField({
       name: "featured",
       title: "Featured Category",
       type: "boolean",
@@ -164,13 +128,5 @@ export default defineType({
       ],
     }),
 
-    defineField({
-      name: "productCount",
-      title: "Product Count",
-      type: "number",
-      readOnly: true,
-      description:
-        "Automatically calculated based on products in this category",
-    }),
   ],
 });

--- a/src/sanity/schemaTypes/documents/product.tsx
+++ b/src/sanity/schemaTypes/documents/product.tsx
@@ -39,11 +39,6 @@ export const productType = defineType({
       options: { field: "store.slug.current" },
     }),
     defineField({
-      name: "body",
-      type: "portableText",
-      group: "editorial",
-    }),
-    defineField({
       name: "store",
       type: "shopifyProduct",
       description: "Product data from Shopify (read-only)",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,5 +32,5 @@
     "next.config.mjs",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "storefront-accelerator"]
 }


### PR DESCRIPTION
## Summary
- **Remove 4 dead schema fields** that are never queried or rendered in the frontend
- Category: `level` (redundant — hierarchy via parentCategory refs), `visibility` (never queried — filtered by categoryType), `productCount` (redundant — computed dynamically in GROQ)
- Product: `body` portableText (never projected — PDP uses Shopify store.description)
- Exclude `storefront-accelerator/` from TypeScript compilation (cloned repo breaking builds)
- 5 files changed, −103 lines
- Build passes ✓