### PR TITLE
v2.15.0: WCAG 2.1 AA audit + schema cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "zone2run",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "portless zone2 next dev --turbopack",
     "build": "next build",
     "build:analyze": "ANALYZE=true next build --webpack",
     "start": "next start",

--- a/sanity.types.ts
+++ b/sanity.types.ts
@@ -1100,7 +1100,6 @@ export type Product = {
   hidden?: string;
   titleProxy?: ProxyString;
   slugProxy?: ProxyString;
-  body?: PortableText;
   store?: ShopifyProduct;
   seo?: Seo;
   category?: {
@@ -1279,11 +1278,6 @@ export type Category = {
     [internalGroqTypeReferenceTo]?: "category";
   };
   categoryType?: "main" | "subcategory" | "specific";
-  level?: number;
-  visibility?: {
-    navigation?: boolean;
-    filters?: boolean;
-  };
   featured?: boolean;
   sortOrder?: number;
   seo?: {
@@ -1291,7 +1285,6 @@ export type Category = {
     description?: string;
     keywords?: Array<string>;
   };
-  productCount?: number;
 };
 
 export type LinkExternal = {

--- a/schema.json
+++ b/schema.json
@@ -7263,14 +7263,6 @@
         },
         "optional": true
       },
-      "body": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "inline",
-          "name": "portableText"
-        },
-        "optional": true
-      },
       "store": {
         "type": "objectAttribute",
         "value": {
@@ -8344,36 +8336,6 @@
         },
         "optional": true
       },
-      "level": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "number"
-        },
-        "optional": true
-      },
-      "visibility": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "object",
-          "attributes": {
-            "navigation": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "boolean"
-              },
-              "optional": true
-            },
-            "filters": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "boolean"
-              },
-              "optional": true
-            }
-          }
-        },
-        "optional": true
-      },
       "featured": {
         "type": "objectAttribute",
         "value": {
@@ -8418,13 +8380,6 @@
               "optional": true
             }
           }
-        },
-        "optional": true
-      },
-      "productCount": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "number"
         },
         "optional": true
       }

--- a/src/app/[locale]/(main)/blog/page.tsx
+++ b/src/app/[locale]/(main)/blog/page.tsx
@@ -66,9 +66,9 @@ export default async function BlogPage() {
                   )}
                 </div>
                 <div className="space-y-2">
-                  <h3 className="text-sm text-black line-clamp-2">
+                  <h2 className="text-sm text-black line-clamp-2">
                     {post.title}
-                  </h3>
+                  </h2>
 
                   {post.excerpt && <p className="text-xs">{post.excerpt}</p>}
 

--- a/src/app/[locale]/(main)/layout.tsx
+++ b/src/app/[locale]/(main)/layout.tsx
@@ -43,7 +43,7 @@ export default async function MainLayout({
   const { isEnabled: isDraft } = await draftMode();
 
   return (
-    <html lang="en">
+    <html lang={locale}>
       <head>
         {/* DNS Prefetch - resolve domain names early */}
         <link rel="dns-prefetch" href="//cdn.sanity.io" />

--- a/src/app/[locale]/(main)/products/[handle]/page.tsx
+++ b/src/app/[locale]/(main)/products/[handle]/page.tsx
@@ -101,7 +101,7 @@ export default async function ProductPage({
               <ProductGalleryClient images={product.images} />
             ) : (
               <div className="w-full relative aspect-[4/5] flex items-center justify-center bg-gray-100">
-                <p className="text-gray-400">No images available</p>
+                <p className="text-gray-500">No images available</p>
               </div>
             )}
           </div>

--- a/src/app/[locale]/(main)/search/page.tsx
+++ b/src/app/[locale]/(main)/search/page.tsx
@@ -67,7 +67,7 @@ export default async function SearchPage({
     <div className="px-2 py-8">
       <div className="flex justify-between items-center mb-4 px-2">
         <h1 className="text-xs">Results for &quot;{q}&quot;</h1>
-        <span className="text-xs text-gray-500">
+        <span className="text-xs text-gray-500" aria-live="polite" aria-atomic="true">
           {results.totalCount} products
         </span>
       </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -53,6 +53,17 @@ body {
 }
 
 
+@layer base {
+  a:focus-visible,
+  button:focus-visible,
+  [role="button"]:focus-visible,
+  select:focus-visible,
+  [tabindex]:focus-visible {
+    outline: 2px solid black;
+    outline-offset: 2px;
+  }
+}
+
 @layer components {
   /* Consistent vertical spacing between homepage/page sections */
   .section-spacing {

--- a/src/components/CartModal.tsx
+++ b/src/components/CartModal.tsx
@@ -7,6 +7,8 @@ import { useModalScrollRestoration } from "@/hooks/useModalScrollRestoration";
 
 // Lazy load FocusLock - only needed when modal is visible
 const FocusLock = dynamic(() => import("react-focus-lock"), { ssr: false });
+import { useEscapeKey } from "@/hooks/useEscapeKey";
+import { useInertBackground } from "@/hooks/useInertBackground";
 import { useHasMounted } from "@/hooks/useHasMounted";
 import Image from "next/image";
 import { useCartStore } from "@/lib/cart/store";
@@ -43,6 +45,9 @@ function CartModal({
       unlockScroll();
     }, 300);
   };
+
+  useEscapeKey(isCartOpen, handleClose);
+  useInertBackground(isCartOpen);
 
   const [isRedirecting, setIsRedirecting] = useState(false);
   const [isCheckingAvailability, setIsCheckingAvailability] = useState(false);

--- a/src/components/CountrySwitcher.tsx
+++ b/src/components/CountrySwitcher.tsx
@@ -9,6 +9,8 @@ import { COUNTRY_MAP, SUPPORTED_COUNTRIES } from "@/lib/locale/countries";
 import { countryToLocale } from "@/lib/locale/localeUtils";
 import { Backdrop } from "@/components/ui/Backdrop";
 import { ModalHeader } from "@/components/ui/ModalHeader";
+import { useEscapeKey } from "@/hooks/useEscapeKey";
+import { useInertBackground } from "@/hooks/useInertBackground";
 import { useModalScrollRestoration } from "@/hooks/useModalScrollRestoration";
 
 const FocusLock = dynamic(() => import("react-focus-lock"), { ssr: false });
@@ -45,6 +47,9 @@ export default function CountrySwitcher({ isOpen, onClose }: CountrySwitcherProp
       unlockScroll();
     }, 300);
   }, [onClose, unlockScroll]);
+
+  useEscapeKey(isOpen, handleClose);
+  useInertBackground(isOpen);
 
   const handleSelect = useCallback(
     (newCountry: string) => {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -64,18 +64,15 @@ function Header({
       <header className="fixed top-0 left-0 right-0 z-40 bg-white shadow-sm">
         <nav className="text-sm flex justify-between items-center h-12 px-2 xl:h-16 relative bg-white xl:px-4 text-xs">
           <div className="flex items-center gap-2">
-            {/* Mobile: Hamburger menu */}
+            {/* Mobile: Menu button */}
             <button
-              aria-label="Open menu"
               onClick={() => {
                 lockScroll();
                 setIsMenuOpen(true);
               }}
-              className="xl:hidden flex flex-col justify-between w-4 h-3 z-50 hover:text-gray-300 cursor-pointer"
+              className="xl:hidden hover:text-gray-500 text-xs cursor-pointer"
             >
-              <span className="w-full h-0.5 bg-current" />
-              <span className="w-full h-0.5 bg-current" />
-              <span className="w-full h-0.5 bg-current" />
+              Menu
             </button>
 
             {/* Desktop: Nav links */}

--- a/src/components/LoadMoreButton.tsx
+++ b/src/components/LoadMoreButton.tsx
@@ -18,7 +18,7 @@ export default function LoadMoreButton({
       <button
         type="button"
         onClick={onLoadMore}
-        className="text-xs hover:underline"
+        className="text-xs hover:underline min-h-touch-target px-4 flex items-center"
       >
         Load More ({remainingCount})
       </button>

--- a/src/components/MobileCarousel.tsx
+++ b/src/components/MobileCarousel.tsx
@@ -59,7 +59,7 @@ const MobileCarousel = memo(function MobileCarousel({
           >
             <Image
               src={image.url}
-              alt=""
+              alt={image.alt || "Product image"}
               fill
               sizes={sizes}
               className="object-cover"

--- a/src/components/SearchModal.tsx
+++ b/src/components/SearchModal.tsx
@@ -1,18 +1,24 @@
 "use client";
 
 import { useState, useTransition, useRef, useEffect } from "react";
+import dynamic from "next/dynamic";
 import LocaleLink from "@/components/LocaleLink";
 import { searchProducts } from "@/lib/actions/search";
 import { enrichRecentlyViewedPrices } from "@/lib/actions/recentlyViewed";
 import { useLocale } from "@/lib/locale/LocaleContext";
 import { useRecentlyViewedStore } from "@/lib/recentlyViewed/store";
 import { useModalScrollRestoration } from "@/hooks/useModalScrollRestoration";
+import { useEscapeKey } from "@/hooks/useEscapeKey";
+import { useInertBackground } from "@/hooks/useInertBackground";
 import ProductCard from "./ProductCard";
 import RecentlyViewedSection from "./RecentlyViewedSection";
 import { Backdrop } from "@/components/ui/Backdrop";
+import { ModalHeader } from "@/components/ui/ModalHeader";
 import { NavLink } from "@/components/ui/NavLink";
 import type { SanitySearchResult } from "@/lib/actions/search";
 import type { CardProduct } from "@/types/cardProduct";
+
+const FocusLock = dynamic(() => import("react-focus-lock"), { ssr: false });
 
 interface SearchModalProps {
   isOpen: boolean;
@@ -37,6 +43,9 @@ export default function SearchModal({ isOpen, onClose }: SearchModalProps) {
       inputRef.current?.focus();
     }
   }, [isOpen]);
+
+  useEscapeKey(isOpen, handleClose);
+  useInertBackground(isOpen);
 
   const handleSearch = (value: string) => {
     setQuery(value);
@@ -68,7 +77,7 @@ export default function SearchModal({ isOpen, onClose }: SearchModalProps) {
     }
   };
 
-  const handleClose = () => {
+  function handleClose() {
     setQuery("");
     setResults(null);
     setRecentlyViewed([]);
@@ -77,148 +86,147 @@ export default function SearchModal({ isOpen, onClose }: SearchModalProps) {
     setTimeout(() => {
       unlockScroll();
     }, 300);
-  };
+  }
 
   return (
     <>
       <Backdrop isOpen={isOpen} onClick={handleClose} blur={false} />
 
-      {/* Modal - Full screen on mobile, 25vw on desktop (matches CartModal) */}
-      <div
-        className={
-          "fixed top-0 right-0 h-[100dvh] w-full xl:w-1/2 bg-white z-50 transform transition-transform duration-300 overflow-hidden flex flex-col" +
-          (isOpen ? " translate-x-0" : " translate-x-full")
-        }
-      >
-        {/* Fixed Header */}
-        <div className="bg-white z-10 flex-shrink-0">
-          <div className="text-xs flex justify-between items-center h-12 xl:h-16 px-4 xl:px-4">
-            <span>Search</span>
-            <button
-              className="text-xs hover:text-gray-500"
-              onClick={handleClose}
-            >
-              Close
-            </button>
-          </div>
-          <div className="border-b border-gray-300 w-full" />
-        </div>
+      {/* Modal - Full screen on mobile, half on desktop */}
+      <FocusLock disabled={!isOpen}>
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="search-title"
+          className={
+            "fixed top-0 right-0 h-[100dvh] w-full xl:w-1/2 bg-white z-50 transform transition-transform duration-300 overflow-hidden flex flex-col" +
+            (isOpen ? " translate-x-0" : " translate-x-full")
+          }
+        >
+          <ModalHeader
+            title="Search"
+            titleId="search-title"
+            onClose={handleClose}
+            bordered
+          />
 
-        {/* Scrollable Content */}
-        <div className="flex-1 overflow-y-auto px-4 xl:px-4">
-          {/* Search Input */}
-          <div className="mt-6">
-            <input
-              ref={inputRef}
-              type="text"
-              value={query}
-              onChange={(e) => handleSearch(e.target.value)}
-              onFocus={handleInputFocus}
-              placeholder="What are you looking for?"
-              className="w-full py-2 border-b border-gray-300 text-base md:text-sm focus:outline-none focus:border-black"
-            />
-          </div>
-
-          {isPending && query && (
-            <p className="text-xs text-gray-500 mt-4">Searching...</p>
-          )}
-
-          {/* Brands */}
-          {results?.brands && results.brands.length > 0 && (
-            <div className="mt-8">
-              <span className="text-gray-500 text-xs block mb-3">Brands</span>
-              {results.brands.map((brand) => (
-                <NavLink
-                  key={brand._id}
-                  href={`/brands/${brand.slug}`}
-                  onClick={handleClose}
-                  className="mt-2"
-                >
-                  {brand.name}
-                </NavLink>
-              ))}
+          {/* Scrollable Content */}
+          <div className="flex-1 overflow-y-auto px-4 xl:px-4">
+            {/* Search Input */}
+            <div className="mt-6">
+              <input
+                ref={inputRef}
+                type="text"
+                value={query}
+                onChange={(e) => handleSearch(e.target.value)}
+                onFocus={handleInputFocus}
+                placeholder="What are you looking for?"
+                aria-label="Search products"
+                className="w-full py-2 border-b border-gray-300 text-base md:text-sm focus:outline-none focus:border-black"
+              />
             </div>
-          )}
 
-          {/* Collections */}
-          {results?.collections && results.collections.length > 0 && (
-            <div className="mt-8">
-              <span className="text-gray-500 text-xs block mb-3">
-                Collections
-              </span>
-              {results.collections.map((collection) => (
-                <NavLink
-                  key={collection._id}
-                  href={`/collections/${collection.slug}`}
-                  onClick={handleClose}
-                  className="mt-2"
-                >
-                  {collection.title}
-                </NavLink>
-              ))}
-            </div>
-          )}
+            {isPending && query && (
+              <p className="text-xs text-gray-500 mt-4">Searching...</p>
+            )}
 
-          {/* Recently Viewed - shown in default state (no search query) */}
-          {results?.isDefault && (
-            <RecentlyViewedSection
-              products={recentlyViewed}
-              onProductClick={handleClose}
-            />
-          )}
-
-          {/* Products */}
-          {results?.products && results.products.length > 0 && (
-            <div className="mt-12 mb-8">
-              <div className="flex justify-between items-center mb-4 text-xs">
-                <span>{results.isDefault ? "New arrivals" : "Results"}</span>
-                <span>{results.totalCount} products</span>
-              </div>
-              <div className="grid grid-cols-2 xl:grid-cols-4 gap-2">
-                {results.products.map((product) => (
-                  <LocaleLink
-                    key={product._id}
-                    href={`/products/${product.handle}`}
+            {/* Brands */}
+            {results?.brands && results.brands.length > 0 && (
+              <div className="mt-8">
+                <span className="text-gray-500 text-xs block mb-3">Brands</span>
+                {results.brands.map((brand) => (
+                  <NavLink
+                    key={brand._id}
+                    href={`/brands/${brand.slug}`}
                     onClick={handleClose}
+                    className="mt-2"
                   >
-                    <ProductCard
-                      product={product as CardProduct}
-                      sizes="(max-width: 1279px) calc(50vw - 12px), calc(25vw - 10px)"
-                      disableGallery
-                    />
-                  </LocaleLink>
+                    {brand.name}
+                  </NavLink>
                 ))}
               </div>
-            </div>
-          )}
+            )}
 
-          {/* No results */}
-          {results &&
-            !results.isDefault &&
-            results.products?.length === 0 &&
-            results.brands?.length === 0 &&
-            results.collections?.length === 0 && (
-              <p className="text-xs text-gray-500 mt-12">
-                No results found for &quot;{query}&quot;
-              </p>
+            {/* Collections */}
+            {results?.collections && results.collections.length > 0 && (
+              <div className="mt-8">
+                <span className="text-gray-500 text-xs block mb-3">
+                  Collections
+                </span>
+                {results.collections.map((collection) => (
+                  <NavLink
+                    key={collection._id}
+                    href={`/collections/${collection.slug}`}
+                    onClick={handleClose}
+                    className="mt-2"
+                  >
+                    {collection.title}
+                  </NavLink>
+                ))}
+              </div>
+            )}
+
+            {/* Recently Viewed - shown in default state (no search query) */}
+            {results?.isDefault && (
+              <RecentlyViewedSection
+                products={recentlyViewed}
+                onProductClick={handleClose}
+              />
+            )}
+
+            {/* Products */}
+            {results?.products && results.products.length > 0 && (
+              <div className="mt-12 mb-8">
+                <div className="flex justify-between items-center mb-4 text-xs">
+                  <span>{results.isDefault ? "New arrivals" : "Results"}</span>
+                  <span aria-live="polite" aria-atomic="true">{results.totalCount} products</span>
+                </div>
+                <div className="grid grid-cols-2 xl:grid-cols-4 gap-2">
+                  {results.products.map((product) => (
+                    <LocaleLink
+                      key={product._id}
+                      href={`/products/${product.handle}`}
+                      onClick={handleClose}
+                    >
+                      <ProductCard
+                        product={product as CardProduct}
+                        sizes="(max-width: 1279px) calc(50vw - 12px), calc(25vw - 10px)"
+                        disableGallery
+                      />
+                    </LocaleLink>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* No results */}
+            {results &&
+              !results.isDefault &&
+              results.products?.length === 0 &&
+              results.brands?.length === 0 &&
+              results.collections?.length === 0 && (
+                <p className="text-xs text-gray-500 mt-12">
+                  No results found for &quot;{query}&quot;
+                </p>
+              )}
+          </div>
+
+          {/* See results button - fixed at bottom */}
+          {results?.products &&
+            results.products.length > 0 &&
+            !results.isDefault && (
+              <div className="bg-white border-t border-gray-300 p-4 xl:px-16 flex-shrink-0">
+                <LocaleLink
+                  href={`/search?q=${encodeURIComponent(query)}`}
+                  onClick={handleClose}
+                  className="block w-full bg-black text-white text-center py-3 text-xs hover:bg-gray-800"
+                >
+                  See results ({results.totalCount})
+                </LocaleLink>
+              </div>
             )}
         </div>
-
-        {/* See results button - fixed at bottom */}
-        {results?.products &&
-          results.products.length > 0 &&
-          !results.isDefault && (
-            <div className="bg-white border-t border-gray-300 p-4 xl:px-16 flex-shrink-0">
-              <LocaleLink
-                href={`/search?q=${encodeURIComponent(query)}`}
-                onClick={handleClose}
-                className="block w-full bg-black text-white text-center py-3 text-xs hover:bg-gray-800"
-              >
-                See results ({results.totalCount})
-              </LocaleLink>
-            </div>
-          )}
-      </div>
+      </FocusLock>
     </>
   );
 }

--- a/src/components/header/DesktopDropdown.tsx
+++ b/src/components/header/DesktopDropdown.tsx
@@ -49,7 +49,7 @@ export default function DesktopDropdown({
     const links = menuConfig?.help?.links || [];
     return (
       <div className="py-4 px-4">
-        <h3 className="text-sm mb-4">Help & Support</h3>
+        <p className="text-sm mb-4">Help & Support</p>
         <div className="space-y-3">
           {links.map((link, index) =>
             link.url.startsWith("http") ? (
@@ -83,7 +83,7 @@ export default function DesktopDropdown({
       <div className="flex justify-between py-4 px-4">
         {/* Left side - Editorial titles */}
         <div>
-          <h3 className="text-xs mb-4">Editorials</h3>
+          <p className="text-xs mb-4">Editorials</p>
           <div className="space-y-2">
             <LocaleLink
               href="/blog"
@@ -111,7 +111,7 @@ export default function DesktopDropdown({
 
         {/* Right side - Latest 4 editorials with images */}
         <div className="w-[70vw]">
-          <h3 className="text-xs mb-2">Latest Editorials</h3>
+          <p className="text-xs mb-2">Latest Editorials</p>
           <div className="grid grid-cols-4 gap-1">
             {blogPosts?.slice(0, 4).map((post) => {
               if (!post?.slug?.current) return null;

--- a/src/components/header/DropdownContent.tsx
+++ b/src/components/header/DropdownContent.tsx
@@ -151,7 +151,7 @@ const DropdownContent = memo(function DropdownContent({
 
         {/* Brands Column */}
         <div>
-          <h3 className="text-xs mb-3 mt-2">Brands</h3>
+          <p className="text-xs mb-3 mt-2">Brands</p>
           <div className="space-y-1">
             {brands?.map((brand) => {
               if (!brand?.slug?.current) return null;
@@ -172,7 +172,7 @@ const DropdownContent = memo(function DropdownContent({
 
       {/* Featured Collections Column - Right side */}
       <div className="w-[50vw]">
-        <h3 className="text-xs mb-3 mt-2">Featured Collections</h3>
+        <p className="text-xs mb-3 mt-2">Featured Collections</p>
         <div className="grid grid-cols-4 gap-1">
           {featuredCollections?.slice(0, 4).map((collection) => {
             if (!collection?.slug?.current) return null;

--- a/src/components/homepage/EditorialModule.tsx
+++ b/src/components/homepage/EditorialModule.tsx
@@ -120,7 +120,18 @@ const EditorialModuleComponent = memo(function EditorialModuleComponent({
         </LocaleLink>
       </div>
 
-      <div className="overflow-hidden" ref={emblaRef}>
+      <div
+        className="overflow-hidden"
+        ref={emblaRef}
+        tabIndex={0}
+        role="group"
+        aria-label="Editorial posts carousel"
+        onKeyDown={(e) => {
+          if (!emblaApi) return;
+          if (e.key === "ArrowLeft") { e.preventDefault(); emblaApi.scrollPrev(); }
+          if (e.key === "ArrowRight") { e.preventDefault(); emblaApi.scrollNext(); }
+        }}
+      >
         <div className="flex gap-2">
           {postsWithImages.map(({ post, imageSelection }) => {
             const selectedImage = getSelectedImage(post, imageSelection);

--- a/src/components/menumodal/GenderMenuContent.tsx
+++ b/src/components/menumodal/GenderMenuContent.tsx
@@ -67,10 +67,10 @@ function GenderMenuContent({
         const isOpen = hasCategory(category);
         return (
           <div key={category}>
-            <div className="px-2 py-2">
+            <div className="px-2">
               <button
                 onClick={() => toggleCategory(category)}
-                className="w-full text-left flex justify-between items-center"
+                className="w-full text-left flex justify-between items-center min-h-touch-target"
               >
                 <span className="text-xs capitalize">{category}</span>
                 <ChevronRightIcon
@@ -106,7 +106,7 @@ function GenderMenuContent({
                         {subSubcats.length > 0 ? (
                           <>
                             <button
-                              className="text-xs hover:text-gray-500 text-left flex-1"
+                              className="text-xs hover:text-gray-500 text-left flex-1 min-h-touch-target flex items-center"
                               onClick={() =>
                                 toggleSubcategory(subcategory.slug.current)
                               }
@@ -117,7 +117,8 @@ function GenderMenuContent({
                               onClick={() =>
                                 toggleSubcategory(subcategory.slug.current)
                               }
-                              className="ml-2 p-1"
+                              className="ml-2 p-1 min-w-touch-target min-h-touch-target flex items-center justify-center"
+                              aria-label={`${hasSubcategory(subcategory.slug.current) ? "Collapse" : "Expand"} ${subcategory.title}`}
                             >
                               <ChevronRightIcon
                                 className="w-2 h-2 text-black"
@@ -180,10 +181,10 @@ function GenderMenuContent({
       {/* Brands Section */}
       {brands && brands.length > 0 && (
         <div>
-          <div className="px-2 py-2">
+          <div className="px-2">
             <button
               onClick={() => toggleBrand("brands")}
-              className="w-full text-left flex justify-between items-center"
+              className="w-full text-left flex justify-between items-center min-h-touch-target"
             >
               <span className="text-xs">Brands</span>
               <ChevronRightIcon

--- a/src/components/menumodal/MenuModal.tsx
+++ b/src/components/menumodal/MenuModal.tsx
@@ -5,6 +5,8 @@ import dynamic from "next/dynamic";
 
 // Lazy load FocusLock - only needed when modal is visible
 const FocusLock = dynamic(() => import("react-focus-lock"), { ssr: false });
+import { useEscapeKey } from "@/hooks/useEscapeKey";
+import { useInertBackground } from "@/hooks/useInertBackground";
 import { useModalScrollRestoration } from "@/hooks/useModalScrollRestoration";
 import GenderMenuContent from "./GenderMenuContent";
 import HelpContent from "./HelpContent";
@@ -39,6 +41,9 @@ function MenuModal({
       unlockScroll();
     }, 300);
   };
+
+  useEscapeKey(isMenuOpen, handleClose);
+  useInertBackground(isMenuOpen);
 
   // Handle client-side mounting
   useEffect(() => {

--- a/src/components/plp/FilterContent.tsx
+++ b/src/components/plp/FilterContent.tsx
@@ -30,7 +30,7 @@ function FilterPill({
   return (
     <button
       type="button"
-      className={`inline-flex items-center gap-2 px-2 py-1 text-xs transition-colors w-fit ${
+      className={`inline-flex items-center gap-2 px-2 py-2 text-xs transition-colors w-fit min-h-touch-target ${
         isSelected ? "bg-black text-white" : "bg-gray-100 hover:bg-gray-200"
       }`}
       onClick={onToggle}

--- a/src/components/plp/FilterSortButton.tsx
+++ b/src/components/plp/FilterSortButton.tsx
@@ -15,7 +15,7 @@ export function FilterSortButton({
     <div className="flex items-center justify-between px-2 mb-4">
       <button
         type="button"
-        className="text-xs hover:text-gray-500"
+        className="text-xs hover:text-gray-500 min-h-touch-target flex items-center"
         onClick={onClick}
         aria-label={`Open filters${activeCount > 0 ? `, ${activeCount} active` : ""}`}
       >

--- a/src/components/plp/FilterSortModal.tsx
+++ b/src/components/plp/FilterSortModal.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import dynamic from "next/dynamic";
+import { useEscapeKey } from "@/hooks/useEscapeKey";
+import { useInertBackground } from "@/hooks/useInertBackground";
 import { useModalScrollRestoration } from "@/hooks/useModalScrollRestoration";
 import { FilterContent } from "./FilterContent";
 import { SortContent } from "./SortContent";
@@ -53,6 +55,9 @@ export function FilterSortModal({
       unlockScroll();
     }, 300);
   };
+
+  useEscapeKey(isOpen, handleClose);
+  useInertBackground(isOpen);
 
   const handleClearAll = () => {
     onFiltersChange({

--- a/src/components/product/AddedToCartModal.tsx
+++ b/src/components/product/AddedToCartModal.tsx
@@ -82,7 +82,7 @@ const AddedToCartModal = memo(function AddedToCartModal({
                   setIsCartOpen(true);
                   hideAddedToCart();
                 }}
-                className="px-4 py-1 bg-black text-white text-xs cursor-pointer"
+                className="px-4 py-2 bg-black text-white text-xs cursor-pointer min-h-touch-target"
               >
                 View Cart
               </button>

--- a/src/components/product/ProductEditorialImages.tsx
+++ b/src/components/product/ProductEditorialImages.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useRef, useCallback } from "react";
 import Image from "next/image";
 import { urlFor } from "@/sanity/lib/image";
 
@@ -27,9 +27,27 @@ export default function ProductEditorialImages({
     return null;
   }
 
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const scrollBy = useCallback((direction: 1 | -1) => {
+    const container = scrollRef.current;
+    if (!container) return;
+    const slideWidth = container.firstElementChild?.firstElementChild?.clientWidth ?? container.clientWidth * 0.7;
+    container.scrollBy({ left: direction * (slideWidth + 8), behavior: "smooth" });
+  }, []);
+
   return (
     <div className="ml-2 my-8 md:my-12 xl:my-16 pr-2 w-full">
-      <div className="overflow-x-auto snap-x snap-mandatory scrollbar-hide -mx-2 px-2">
+      <div
+        ref={scrollRef}
+        className="overflow-x-auto snap-x snap-mandatory scrollbar-hide -mx-2 px-2"
+        tabIndex={0}
+        role="group"
+        aria-label="Editorial images carousel"
+        onKeyDown={(e) => {
+          if (e.key === "ArrowLeft") { e.preventDefault(); scrollBy(-1); }
+          if (e.key === "ArrowRight") { e.preventDefault(); scrollBy(1); }
+        }}
+      >
         <div className="flex gap-2">
           {editorialImages.map((item) => {
             const imageUrl = item.image?.asset?.url;

--- a/src/components/product/ProductForm.tsx
+++ b/src/components/product/ProductForm.tsx
@@ -80,7 +80,7 @@ export function ProductPrice({
         {formatCurrency(price.amount, price.currencyCode)}
       </p>
       {hasDiscount && (
-        <p className="text-xs text-gray-400 line-through">
+        <p className="text-xs text-gray-500 line-through">
           {formatCurrency(compareAtPrice.amount, compareAtPrice.currencyCode)}
         </p>
       )}

--- a/src/components/product/ProductGalleryClient.tsx
+++ b/src/components/product/ProductGalleryClient.tsx
@@ -50,6 +50,11 @@ export default function ProductGalleryClient({
       className="relative aspect-[4/5] xl:w-full xl:h-[92.5vh]"
       role="group"
       aria-label="Product image gallery"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === "ArrowLeft") { e.preventDefault(); scrollPrev(); }
+        if (e.key === "ArrowRight") { e.preventDefault(); scrollNext(); }
+      }}
     >
       {/* Embla carousel container */}
       <div className="overflow-hidden h-full" ref={emblaRef} aria-hidden="true">

--- a/src/components/product/VariantSelector.tsx
+++ b/src/components/product/VariantSelector.tsx
@@ -82,11 +82,11 @@ const VariantSelector = memo(function VariantSelector({
             <button
               key={size}
               aria-label={`Select size ${size}${!isAvailable ? ", unavailable" : ""}${isSelected ? ", selected" : ""}`}
-              className={`py-1 px-4 border text-center text-xs transition-colors ${
+              className={`py-2 px-4 border text-center text-xs transition-colors min-h-touch-target ${
                 isOneSize ? "w-full" : ""
               } ${
                 !isAvailable
-                  ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                  ? "bg-gray-100 text-gray-500 border-gray-200 cursor-not-allowed"
                   : isSelected
                   ? "bg-black text-white border-black"
                   : "border-gray-300 hover:bg-black hover:text-white hover:border-black"

--- a/src/components/ui/CollapsibleSection.tsx
+++ b/src/components/ui/CollapsibleSection.tsx
@@ -26,6 +26,7 @@ export function CollapsibleSection({
       className={`overflow-hidden transition-all ease-in-out ${
         isOpen ? "opacity-100" : "opacity-0"
       } ${className}`}
+      aria-hidden={!isOpen}
       style={{
         maxHeight: isOpen ? `${maxHeight}px` : "0",
         transitionDuration: `${duration}ms`,

--- a/src/components/ui/ModalHeader.tsx
+++ b/src/components/ui/ModalHeader.tsx
@@ -25,7 +25,7 @@ export function ModalHeader({
       <div className="text-xs flex justify-between items-center h-full px-2">
         <span id={titleId}>{title}</span>
         <button
-          className="text-xs hover:text-gray-500"
+          className="text-xs hover:text-gray-500 min-h-touch-target min-w-touch-target flex items-center justify-end"
           onClick={onClose}
           aria-label={`Close ${title.toLowerCase()}`}
         >

--- a/src/hooks/useEscapeKey.ts
+++ b/src/hooks/useEscapeKey.ts
@@ -1,0 +1,20 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Closes a modal when the Escape key is pressed.
+ * Uses a ref to track the latest callback, avoiding stale closures
+ * without requiring callers to memoize their onClose function.
+ */
+export function useEscapeKey(isOpen: boolean, onClose: () => void) {
+  const callbackRef = useRef(onClose);
+  callbackRef.current = onClose;
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") callbackRef.current();
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [isOpen]);
+}

--- a/src/hooks/useInertBackground.ts
+++ b/src/hooks/useInertBackground.ts
@@ -1,0 +1,25 @@
+import { useEffect } from "react";
+
+/**
+ * Sets inert on #main-content and the site <header> when a modal is open,
+ * preventing keyboard/pointer interaction with background content.
+ */
+export function useInertBackground(isOpen: boolean) {
+  useEffect(() => {
+    const main = document.getElementById("main-content");
+    const header = document.querySelector("header");
+
+    if (isOpen) {
+      main?.setAttribute("inert", "");
+      header?.setAttribute("inert", "");
+    } else {
+      main?.removeAttribute("inert");
+      header?.removeAttribute("inert");
+    }
+
+    return () => {
+      main?.removeAttribute("inert");
+      header?.removeAttribute("inert");
+    };
+  }, [isOpen]);
+}

--- a/src/sanity/schemaTypes/category.ts
+++ b/src/sanity/schemaTypes/category.ts
@@ -8,20 +8,15 @@ export default defineType({
     select: {
       title: "title",
       media: "image",
-      productCount: "productCount",
       categoryType: "categoryType",
       parentCategory: "parentCategory.title",
     },
-    prepare({ title, media, productCount, categoryType, parentCategory }) {
+    prepare({ title, media, categoryType, parentCategory }) {
       const typeLabel = categoryType ? `[${categoryType}]` : "";
       const parentLabel = parentCategory ? ` → ${parentCategory}` : "";
-      const countLabel = productCount
-        ? `${productCount} products`
-        : "No products";
 
       return {
         title: `${title}${typeLabel}${parentLabel}`,
-        subtitle: countLabel,
         media,
       };
     },
@@ -96,37 +91,6 @@ export default defineType({
     }),
 
     defineField({
-      name: "level",
-      title: "Hierarchy Level",
-      type: "number",
-      readOnly: true,
-      description:
-        "Automatically calculated: 1=main, 2=subcategory, 3=specific",
-    }),
-
-    defineField({
-      name: "visibility",
-      title: "Visibility",
-      type: "object",
-      fields: [
-        {
-          name: "navigation",
-          type: "boolean",
-          title: "Show in Navigation",
-          initialValue: true,
-          description: "Show this category in the main menu",
-        },
-        {
-          name: "filters",
-          type: "boolean",
-          title: "Show in Filters",
-          initialValue: true,
-          description: "Show this category in product filters",
-        },
-      ],
-    }),
-
-    defineField({
       name: "featured",
       title: "Featured Category",
       type: "boolean",
@@ -164,13 +128,5 @@ export default defineType({
       ],
     }),
 
-    defineField({
-      name: "productCount",
-      title: "Product Count",
-      type: "number",
-      readOnly: true,
-      description:
-        "Automatically calculated based on products in this category",
-    }),
   ],
 });

--- a/src/sanity/schemaTypes/documents/product.tsx
+++ b/src/sanity/schemaTypes/documents/product.tsx
@@ -39,11 +39,6 @@ export const productType = defineType({
       options: { field: "store.slug.current" },
     }),
     defineField({
-      name: "body",
-      type: "portableText",
-      group: "editorial",
-    }),
-    defineField({
       name: "store",
       type: "shopifyProduct",
       description: "Product data from Shopify (read-only)",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,5 +32,5 @@
     "next.config.mjs",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "storefront-accelerator"]
 }


### PR DESCRIPTION
## Summary
- **WCAG 2.1 AA accessibility audit** — focus-visible CSS, modal a11y (FocusLock + inert), touch targets 44x44px, keyboard carousel navigation, heading hierarchy fixes, contrast improvements, aria-live regions, dynamic lang attribute (#168)
- **Schema cleanup** — removed unused Sanity fields from category and product schemas, regenerated types (#169)
- New hooks: `useEscapeKey`, `useInertBackground`
- 33 files changed, 282 insertions, 266 deletions
- Build passes ✓

## Test plan
- [x] All modals: focus trap, inert background, Escape to close
- [x] Keyboard navigation on carousels (PDP gallery, editorial, product editorial images)
- [x] Touch targets ≥ 44x44px on all interactive elements
- [x] Heading hierarchy — no skipped levels
- [x] Screen reader: aria-live on search results, aria-hidden on collapsed sections
- [x] `bun build` passes