### PR TITLE
feat: Sanity audit fixes — defineQuery, ArticleJsonLd, AI crawlers

### DIFF
--- a/src/app/[locale]/(main)/blog/[category]/[postSlug]/page.tsx
+++ b/src/app/[locale]/(main)/blog/[category]/[postSlug]/page.tsx
@@ -9,6 +9,7 @@ import BlogProductCarousel from "@/components/blog/BlogProductCarousel";
 import type { CardProduct } from "@/types/cardProduct";
 import type { PLPProduct } from "@/types/plpProduct";
 import { getSelectedImage } from "@/lib/utils/imageSelection";
+import ArticleJsonLd from "@/components/schemas/ArticleJsonLd";
 
 // ISR: Revalidate every 24 hours, on-demand via Sanity webhook
 export const revalidate = 86400;
@@ -78,9 +79,9 @@ interface BlogProductsModuleValue {
 export default async function PostPage({
   params,
 }: {
-  params: Promise<{ category: string; postSlug: string }>;
+  params: Promise<{ locale: string; category: string; postSlug: string }>;
 }) {
-  const { postSlug } = await params;
+  const { locale, category, postSlug } = await params;
   const post = await getBlogPost(postSlug);
 
   if (!post) return notFound();
@@ -290,6 +291,18 @@ export default async function PostPage({
           )}
         </div>
       )}
+
+      <ArticleJsonLd
+        title={post.title}
+        excerpt={post.excerpt}
+        publishedAt={post.publishedAt}
+        author={post.author}
+        image={post.featuredImage?.asset?.url}
+        readingTime={post.readingTime}
+        locale={locale}
+        categorySlug={category}
+        postSlug={postSlug}
+      />
     </div>
   );
 }

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -4,12 +4,33 @@ export default function robots(): MetadataRoute.Robots {
   const baseUrl =
     process.env.NEXT_PUBLIC_SITE_URL || "https://zone2run-build.vercel.app";
 
+  const disallow = ["/studio/", "/api/", "/order-confirmation"];
+
   return {
     rules: [
       {
         userAgent: "*",
         allow: "/",
-        disallow: ["/studio/", "/api/", "/order-confirmation"],
+        disallow,
+      },
+      {
+        userAgent: "GPTBot",
+        allow: "/",
+        disallow,
+      },
+      {
+        userAgent: "ClaudeBot",
+        allow: "/",
+        disallow,
+      },
+      {
+        userAgent: "PerplexityBot",
+        allow: "/",
+        disallow,
+      },
+      {
+        userAgent: "Google-Extended",
+        allow: "/",
       },
     ],
     sitemap: `${baseUrl}/sitemap.xml`,

--- a/src/components/schemas/ArticleJsonLd.tsx
+++ b/src/components/schemas/ArticleJsonLd.tsx
@@ -1,0 +1,62 @@
+import type { BlogPostingSchema } from "./types";
+
+interface ArticleJsonLdProps {
+  title: string;
+  excerpt?: string;
+  publishedAt?: string;
+  author?: string;
+  image?: string;
+  readingTime?: number;
+  locale: string;
+  categorySlug: string;
+  postSlug: string;
+}
+
+/**
+ * Generates JSON-LD structured data for blog posts (BlogPosting schema).
+ * Helps Google display rich snippets and AI answer engines cite content.
+ */
+export default function ArticleJsonLd({
+  title,
+  excerpt,
+  publishedAt,
+  author,
+  image,
+  readingTime,
+  locale,
+  categorySlug,
+  postSlug,
+}: ArticleJsonLdProps) {
+  const baseUrl =
+    process.env.NEXT_PUBLIC_SITE_URL || "https://zone2run-build.vercel.app";
+  const url = `${baseUrl}/${locale}/blog/${categorySlug}/${postSlug}`;
+
+  const schema: BlogPostingSchema = {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline: title,
+    description: excerpt,
+    image,
+    datePublished: publishedAt,
+    author: author
+      ? { "@type": "Person", name: author }
+      : undefined,
+    publisher: {
+      "@context": "https://schema.org",
+      "@type": "Organization",
+      name: "Zone2Run",
+      url: baseUrl,
+      logo: `${baseUrl}/logo.png`,
+    },
+    mainEntityOfPage: url,
+    wordCount: readingTime ? readingTime * 200 : undefined,
+  };
+
+  return (
+    <script
+      id="article-jsonld"
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+    />
+  );
+}

--- a/src/components/schemas/types.ts
+++ b/src/components/schemas/types.ts
@@ -82,6 +82,25 @@ export interface ContactPointSchema {
   telephone?: string;
 }
 
+// BlogPosting Schema - for blog post pages
+export interface BlogPostingSchema {
+  "@context": "https://schema.org";
+  "@type": "BlogPosting";
+  headline: string;
+  description?: string;
+  image?: string;
+  datePublished?: string;
+  author?: PersonSchema;
+  publisher: OrganizationSchema;
+  mainEntityOfPage: string;
+  wordCount?: number;
+}
+
+export interface PersonSchema {
+  "@type": "Person";
+  name: string;
+}
+
 // Helper type for breadcrumb items (matches existing Breadcrumbs.tsx)
 export interface BreadcrumbItem {
   label: string;

--- a/src/sanity/lib/getBlog.ts
+++ b/src/sanity/lib/getBlog.ts
@@ -1,4 +1,5 @@
 import { cache } from "react";
+import { defineQuery } from "next-sanity";
 import { sanityFetch } from "@/sanity/lib/live";
 import {
   buildLimitClause,
@@ -25,7 +26,7 @@ export interface BlogPostListing {
 
 
 export async function getBlogPosts(limit?: number) {
-  const query = `*[_type == "blogPost"] | order(publishedAt desc) {
+  const query = defineQuery(`*[_type == "blogPost"] | order(publishedAt desc) {
     _id,
     title,
     slug { current },
@@ -48,7 +49,7 @@ export async function getBlogPosts(limit?: number) {
     featuredImage { asset-> { url, "lqip": metadata.lqip }, alt },
     editorialImage { asset-> { url, "lqip": metadata.lqip }, alt },
     readingTime
-  }${buildLimitClause(limit)}`;
+  }${buildLimitClause(limit)}`);
 
   try {
     const { data } = await sanityFetch({ query });
@@ -60,7 +61,7 @@ export async function getBlogPosts(limit?: number) {
 }
 
 export const getBlogPost = cache(async (slug: string) => {
-  const query = `*[_type == "blogPost" && slug.current == $slug][0] {
+  const query = defineQuery(`*[_type == "blogPost" && slug.current == $slug][0] {
     ...,
     _id,
     title,
@@ -94,7 +95,7 @@ export const getBlogPost = cache(async (slug: string) => {
     },
     featuredCollectionLimit,
     featuredCollectionDisplayType
-  }`;
+  }`);
 
   try {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/sanity/lib/getBrands.ts
+++ b/src/sanity/lib/getBrands.ts
@@ -1,4 +1,5 @@
 import { cache } from "react";
+import { defineQuery } from "next-sanity";
 import { sanityFetch } from "@/sanity/lib/live";
 import type { EditorialImage } from "./groqUtils";
 
@@ -15,7 +16,7 @@ interface Brand {
 }
 
 export async function getAllBrands() {
-  const query = `*[_type == "brand"] {
+  const query = defineQuery(`*[_type == "brand"] {
     _id,
     name,
     slug {
@@ -28,7 +29,7 @@ export async function getAllBrands() {
     },
     "productCount": count(*[_type == "product" && references(^._id)]),
     featured
-  } | order(name asc)`;
+  } | order(name asc)`);
 
   try {
     const { data } = await sanityFetch({ query });
@@ -40,7 +41,7 @@ export async function getAllBrands() {
 }
 
 export const getBrandBySlug = cache(async (slug: string) => {
-  const query = `*[_type == "brand" && slug.current == $slug][0] {
+  const query = defineQuery(`*[_type == "brand" && slug.current == $slug][0] {
     _id,
     name,
     description,
@@ -74,7 +75,7 @@ export const getBrandBySlug = cache(async (slug: string) => {
       "linkedProductHandleMens": coalesce(linkedProductMens->shopifyHandle, linkedProductMens->store.slug.current),
       "linkedProductHandleWomens": coalesce(linkedProductWomens->shopifyHandle, linkedProductWomens->store.slug.current)
     }
-  }`;
+  }`);
 
   try {
     const { data } = await sanityFetch({ query, params: { slug } });

--- a/src/sanity/lib/getCategories.ts
+++ b/src/sanity/lib/getCategories.ts
@@ -1,3 +1,4 @@
+import { defineQuery } from "next-sanity";
 import { sanityFetch } from "@/sanity/lib/live";
 import { mapGenderValue } from "./groqUtils";
 import type { MenuData, SubcategoryMenuItem } from "@/types/menu";
@@ -19,7 +20,7 @@ export interface Category {
 }
 
 export async function getAllMainCategories() {
-  const query = `*[_type == "category" && categoryType == "main"] {
+  const query = defineQuery(`*[_type == "category" && categoryType == "main"] {
     _id,
     title,
     slug {
@@ -32,7 +33,7 @@ export async function getAllMainCategories() {
     )]),
     featured,
     sortOrder
-  } | order(sortOrder asc, title asc)`;
+  } | order(sortOrder asc, title asc)`);
 
   try {
     const { data } = await sanityFetch({ query });
@@ -49,8 +50,8 @@ export async function getSubSubcategoriesByParentAndGender(
 ) {
   const dbGender = mapGenderValue(gender);
 
-  const query = `*[_type == "category" && 
-    categoryType == "specific" && 
+  const query = defineQuery(`*[_type == "category" &&
+    categoryType == "specific" &&
     parentCategory->slug.current == $parentSlug
   ] {
     _id,
@@ -68,7 +69,7 @@ export async function getSubSubcategoriesByParentAndGender(
         current
       }
     }
-  } | order(sortOrder asc, title asc)`;
+  } | order(sortOrder asc, title asc)`);
 
   try {
     const { data } = await sanityFetch({ query, params: { parentSlug, gender: dbGender } });
@@ -88,7 +89,7 @@ export async function getSubcategoriesByParentAndGender(
 ) {
   const dbGender = mapGenderValue(gender);
 
-  const query = `*[_type == "category" &&
+  const query = defineQuery(`*[_type == "category" &&
     categoryType == "subcategory" &&
     parentCategory->slug.current == $parentSlug
   ] {
@@ -104,7 +105,7 @@ export async function getSubcategoriesByParentAndGender(
         current
       }
     }
-  } | order(title asc)`;
+  } | order(title asc)`);
 
   try {
     const { data } = await sanityFetch({ query, params: { parentSlug, gender: dbGender } });
@@ -130,7 +131,7 @@ export async function getCategoryHierarchyForGender(
   const dbGender = mapGenderValue(gender);
 
   // Single query that fetches: main categories → subcategories → sub-subcategories
-  const query = `*[_type == "category" && categoryType == "main"] | order(sortOrder asc, title asc) {
+  const query = defineQuery(`*[_type == "category" && categoryType == "main"] | order(sortOrder asc, title asc) {
     _id,
     title,
     slug { current },
@@ -157,7 +158,7 @@ export async function getCategoryHierarchyForGender(
         }
       }
     }
-  }`;
+  }`);
 
   try {
     const { data } = await sanityFetch({ query, params: { gender: dbGender } });

--- a/src/sanity/lib/getCollections.ts
+++ b/src/sanity/lib/getCollections.ts
@@ -1,4 +1,5 @@
 import { cache } from "react";
+import { defineQuery } from "next-sanity";
 import { sanityFetch } from "@/sanity/lib/live";
 import type { PLPProduct } from "@/types/plpProduct";
 import {
@@ -62,7 +63,7 @@ interface Collection {
 }
 
 export async function getAllCollections() {
-  const query = `*[_type == "collection"] | order(sortOrder asc, store.title asc) {
+  const query = defineQuery(`*[_type == "collection"] | order(sortOrder asc, store.title asc) {
     _id,
     "title": store.title,
     "slug": store.slug {
@@ -70,7 +71,7 @@ export async function getAllCollections() {
     },
     ${MENU_IMAGE_PROJECTION},
     sortOrder
-  }`;
+  }`);
 
   try {
     const { data } = await sanityFetch({ query });
@@ -83,7 +84,7 @@ export async function getAllCollections() {
 
 // Get collection info only (no products) - for hero/LCP optimization
 export const getCollectionInfo = cache(async (slug: string): Promise<Omit<Collection, 'products'> | null> => {
-  const query = `*[_type == "collection" && (store.slug.current == $slug || lower(store.slug.current) == lower($slug))][0]{
+  const query = defineQuery(`*[_type == "collection" && (store.slug.current == $slug || lower(store.slug.current) == lower($slug))][0]{
     _id,
     "title": store.title,
     "shopifyId": store.id,
@@ -96,7 +97,7 @@ export const getCollectionInfo = cache(async (slug: string): Promise<Omit<Collec
       _id,
       "handle": coalesce(shopifyHandle, store.slug.current)
     }
-  }`;
+  }`);
 
   try {
     const { data } = await sanityFetch({ query, params: { slug } });
@@ -119,7 +120,7 @@ export async function getCollectionProducts(
   const baseFilter = `*[_type == "product" && (references($collectionId) || (defined(shopifyCollectionIds) && $shopifyIdStr in shopifyCollectionIds))]`;
 
   const params: Record<string, unknown> = { collectionId, shopifyIdStr };
-  const productsQuery = `${baseFilter}${COLLECTION_PRODUCT_PROJECTION}`;
+  const productsQuery = defineQuery(`${baseFilter}${COLLECTION_PRODUCT_PROJECTION}`);
 
   try {
     const { data } = await sanityFetch({ query: productsQuery, params });
@@ -139,15 +140,15 @@ export async function getProductsByCollectionId(
   country?: string,
 ): Promise<PLPProduct[]> {
   // First get the collection to access shopifyId and curatedProducts
-  const collectionQuery = `*[_type == "collection" && _id == $collectionId][0]{
+  const collectionQuery = defineQuery(`*[_type == "collection" && _id == $collectionId][0]{
     _id,
     "shopifyId": store.id,
     "curatedProducts": curatedProducts[]-> {
       _id
     }
-  }`;
+  }`);
 
-  const productsQuery = `*[_type == "product" && (references($collectionId) || (defined(shopifyCollectionIds) && $shopifyIdStr in shopifyCollectionIds))]${COLLECTION_PRODUCT_PROJECTION}`;
+  const productsQuery = defineQuery(`*[_type == "product" && (references($collectionId) || (defined(shopifyCollectionIds) && $shopifyIdStr in shopifyCollectionIds))]${COLLECTION_PRODUCT_PROJECTION}`);
 
   try {
     const { data: collectionData } = await sanityFetch({ query: collectionQuery, params: { collectionId } });

--- a/src/sanity/lib/getHeaderData.ts
+++ b/src/sanity/lib/getHeaderData.ts
@@ -1,4 +1,5 @@
 import { unstable_cache } from "next/cache";
+import { defineQuery } from "next-sanity";
 import { client } from "./client";
 import type {
   MenuData,
@@ -32,7 +33,7 @@ interface HeaderData {
   blogPosts: BlogPostMenuItem[];
 }
 
-const HEADER_QUERY = `{
+const HEADER_QUERY = defineQuery(`{
   "categories": *[_type == "category" && categoryType == "main"] | order(sortOrder asc, title asc) {
     _id,
     title,
@@ -87,7 +88,7 @@ const HEADER_QUERY = `{
     category-> { title, slug { current } },
     featuredImage { asset-> { url, "lqip": metadata.lqip }, alt }
   }
-}`;
+}`);
 
 function transformCategoryArray(
   categories: RawHeaderQueryResult["categories"]

--- a/src/sanity/lib/getHomepage.ts
+++ b/src/sanity/lib/getHomepage.ts
@@ -1,3 +1,4 @@
+import { defineQuery } from "next-sanity";
 import { sanityFetch } from "./live";
 
 // Shared modules projection for both queries
@@ -127,7 +128,7 @@ const modulesProjection = `modules[] {
 export async function getHomepage() {
   // First try to get homepage via siteSettings (new system)
   // Use _id == "siteSettings" to target the singleton specifically
-  const siteSettingsQuery = `*[_id == "siteSettings"][0] {
+  const siteSettingsQuery = defineQuery(`*[_id == "siteSettings"][0] {
     activeHomepage-> {
       _id,
       title,
@@ -136,17 +137,17 @@ export async function getHomepage() {
         ...
       }
     }
-  }.activeHomepage`;
+  }.activeHomepage`);
 
   // Fallback to old home singleton if siteSettings doesn't exist
-  const fallbackQuery = `*[_type == "home"][0] {
+  const fallbackQuery = defineQuery(`*[_type == "home"][0] {
     _id,
     title,
     ${modulesProjection},
     seo {
       ...
     }
-  }`;
+  }`);
 
   try {
     // sanityFetch auto-detects draftMode() — serves draft or published content

--- a/src/sanity/lib/getMenu.ts
+++ b/src/sanity/lib/getMenu.ts
@@ -1,8 +1,9 @@
+import { defineQuery } from "next-sanity";
 import { sanityFetch } from "@/sanity/lib/live";
 import type { MenuConfig } from "@/types/menu";
 
 export async function getMenu(): Promise<MenuConfig | undefined> {
-  const query = `*[_type == "navigationMenu"][0] {
+  const query = defineQuery(`*[_type == "navigationMenu"][0] {
     men {
       featuredCollections[]-> {
         _id,
@@ -49,7 +50,7 @@ export async function getMenu(): Promise<MenuConfig | undefined> {
         _key
       }
     }
-  }`;
+  }`);
 
   try {
     const { data } = await sanityFetch({ query });

--- a/src/sanity/lib/getProducts.ts
+++ b/src/sanity/lib/getProducts.ts
@@ -1,3 +1,4 @@
+import { defineQuery } from "next-sanity";
 import { sanityFetch } from "@/sanity/lib/live";
 import type { SanityProduct } from "@/types/sanityProduct";
 import type { PLPProduct } from "@/types/plpProduct";
@@ -19,7 +20,7 @@ import { deduplicateSizes, type RawProductWithSizes } from "./deduplicateSizes";
 export async function getSanityProductByHandle(
   handle: string,
 ): Promise<SanityProduct | null> {
-  const query = `*[_type == "product" && (shopifyHandle == $handle || store.slug.current == $handle)][0] {
+  const query = defineQuery(`*[_type == "product" && (shopifyHandle == $handle || store.slug.current == $handle)][0] {
     ${PDP_PRODUCT_PROJECTION},
     "colorVariants": colorVariants[]-> {
       _id,
@@ -41,7 +42,7 @@ export async function getSanityProductByHandle(
       },
       caption
     }
-  }`;
+  }`);
 
   try {
     const { data } = await sanityFetch({ query, params: { handle } });
@@ -59,9 +60,9 @@ export async function getSanityProductByHandle(
 export async function getAllProducts(
   country?: string,
 ): Promise<PLPProduct[]> {
-  const query = `*[_type == "product"] {
+  const query = defineQuery(`*[_type == "product"] {
     ${PLP_PRODUCT_PROJECTION}
-  }`;
+  }`);
 
   try {
     const { data } = await sanityFetch({ query });
@@ -88,9 +89,9 @@ export async function getProductsByBrand(
 
   const baseFilter = `*[_type == "product" && (brand->slug.current == $brandSlug || lower(brand->slug.current) == lower($brandSlug))${genderFilter}]`;
 
-  const query = `${baseFilter} {
+  const query = defineQuery(`${baseFilter} {
     ${PLP_PRODUCT_PROJECTION}
-  } | order(_createdAt desc)${buildLimitClause(limit)}`;
+  } | order(_createdAt desc)${buildLimitClause(limit)}`);
 
   try {
     const params = dbGender ? { brandSlug, dbGender } : { brandSlug };
@@ -111,9 +112,9 @@ export async function getProductsByGender(
 ): Promise<PLPProduct[]> {
   const dbGender = mapGenderValue(gender);
 
-  const query = `*[_type == "product" && (gender == $gender || gender == "unisex")] {
+  const query = defineQuery(`*[_type == "product" && (gender == $gender || gender == "unisex")] {
     ${PLP_PRODUCT_PROJECTION}
-  } | order(_createdAt desc)${buildLimitClause(limit)}`;
+  } | order(_createdAt desc)${buildLimitClause(limit)}`);
 
   try {
     const { data } = await sanityFetch({ query, params: { gender: dbGender } });
@@ -137,7 +138,7 @@ export async function getProductsByPath(
 
   const query =
     categoryType === "main"
-      ? `*[_type == "product" &&
+      ? defineQuery(`*[_type == "product" &&
         (gender == $gender || gender == "unisex") &&
         (
           (category->categoryType == "main" &&
@@ -151,14 +152,14 @@ export async function getProductsByPath(
         )
       ] {
     ${PLP_PRODUCT_PROJECTION}
-  } | order(_createdAt desc)${buildLimitClause(limit)}`
-      : `*[_type == "product" &&
+  } | order(_createdAt desc)${buildLimitClause(limit)}`)
+      : defineQuery(`*[_type == "product" &&
         (gender == $gender || gender == "unisex") &&
         category->categoryType == $categoryType &&
         category->slug.current == $categorySlug
       ] {
     ${PLP_PRODUCT_PROJECTION}
-  } | order(_createdAt desc)${buildLimitClause(limit)}`;
+  } | order(_createdAt desc)${buildLimitClause(limit)}`);
 
   try {
     const { data } = await sanityFetch({ query, params: {
@@ -187,7 +188,7 @@ export async function getProductsBySubcategoryIncludingSubSubcategories(
 ): Promise<PLPProduct[]> {
   const dbGender = mapGenderValue(gender);
 
-  const query = `*[_type == "product" &&
+  const query = defineQuery(`*[_type == "product" &&
     (gender == $gender || gender == "unisex") &&
     (
       (category->categoryType == "subcategory" &&
@@ -200,7 +201,7 @@ export async function getProductsBySubcategoryIncludingSubSubcategories(
     )
   ] {
     ${PLP_PRODUCT_PROJECTION}
-  } | order(_createdAt desc)${buildLimitClause(limit)}`;
+  } | order(_createdAt desc)${buildLimitClause(limit)}`);
 
   try {
     const { data } = await sanityFetch({ query, params: {
@@ -230,7 +231,7 @@ export async function getProductsByPath3Level(
 ): Promise<PLPProduct[]> {
   const dbGender = mapGenderValue(gender);
 
-  const query = `*[_type == "product" &&
+  const query = defineQuery(`*[_type == "product" &&
     (gender == $gender || gender == "unisex") &&
     category->categoryType == "specific" &&
     category->slug.current == $subsubcategorySlug &&
@@ -238,7 +239,7 @@ export async function getProductsByPath3Level(
     category->parentCategory->parentCategory->slug.current == $mainCategorySlug
   ] {
     ${PLP_PRODUCT_PROJECTION}
-  } | order(_createdAt desc)${buildLimitClause(limit)}`;
+  } | order(_createdAt desc)${buildLimitClause(limit)}`);
 
   try {
     const { data } = await sanityFetch({ query, params: {
@@ -269,9 +270,9 @@ export async function getProductsByIds(
 ): Promise<CardProduct[]> {
   if (productIds.length === 0) return [];
 
-  const query = `*[_id in $productIds] {
+  const query = defineQuery(`*[_id in $productIds] {
     ${CARD_PRODUCT_PROJECTION}
-  }`;
+  }`);
 
   try {
     const { data } = await sanityFetch({ query, params: { productIds } });
@@ -293,9 +294,9 @@ export async function getRelatedProducts(
   limit: number = 12,
   country?: string,
 ): Promise<CardProduct[]> {
-  const query = `*[_type == "product" && brand->slug.current == $brandSlug && _id != $excludeId] {
+  const query = defineQuery(`*[_type == "product" && brand->slug.current == $brandSlug && _id != $excludeId] {
     ${CARD_PRODUCT_PROJECTION}
-  } | order(_createdAt desc)[0...${limit}]`;
+  } | order(_createdAt desc)[0...${limit}]`);
 
   try {
     const { data } = await sanityFetch({ query, params: { brandSlug, excludeId } });

--- a/src/sanity/lib/getSettings.ts
+++ b/src/sanity/lib/getSettings.ts
@@ -1,3 +1,4 @@
+import { defineQuery } from "next-sanity";
 import { sanityFetch } from "./live";
 
 interface NotFoundPage {
@@ -12,7 +13,7 @@ interface NotFoundPage {
 }
 
 export async function getNotFoundPage(): Promise<NotFoundPage | null> {
-  const query = `*[_type == "settings"][0].notFoundPage {
+  const query = defineQuery(`*[_type == "settings"][0].notFoundPage {
     title,
     body,
     image {
@@ -24,7 +25,7 @@ export async function getNotFoundPage(): Promise<NotFoundPage | null> {
       text,
       link
     }
-  }`;
+  }`);
 
   try {
     const { data } = await sanityFetch({ query });
@@ -62,7 +63,7 @@ export type FooterSettings = {
 };
 
 export async function getFooterSettings(): Promise<FooterSettings | null> {
-  const query = `*[_type == "settings"][0].footer {
+  const query = defineQuery(`*[_type == "settings"][0].footer {
     newsletter {
       heading,
       placeholder,
@@ -94,7 +95,7 @@ export async function getFooterSettings(): Promise<FooterSettings | null> {
       }
     },
     copyrightText
-  }`;
+  }`);
 
   try {
     const { data } = await sanityFetch({ query });

--- a/src/sanity/lib/getSiteSettings.ts
+++ b/src/sanity/lib/getSiteSettings.ts
@@ -1,12 +1,13 @@
+import { defineQuery } from "next-sanity";
 import { sanityFetch } from "@/sanity/lib/live";
 
 export async function getSiteSettings() {
-  const query = `*[_type == "siteSettings"][0] {
+  const query = defineQuery(`*[_type == "siteSettings"][0] {
     productTabs {
       shippingAndReturns,
       payments
     }
-  }`;
+  }`);
 
   try {
     const { data } = await sanityFetch({ query });


### PR DESCRIPTION
## Summary
- **defineQuery() wrappers** on all 30 GROQ queries across 10 files — enables TypeGen type inference for Sanity data fetching
- **ArticleJsonLd component** — new `BlogPosting` JSON-LD schema for blog posts, making them visible to Google rich results and AI answer engines (ChatGPT, Perplexity)
- **AI crawler directives** in robots.txt — explicit allow rules for GPTBot, ClaudeBot, PerplexityBot, Google-Extended
- 14 files changed, 1 new file

## Test plan
- [x] `bun run build` passes (pre-existing type error in untracked `src/lib/product/getAllProducts.ts` is unrelated)
- [x] defineQuery is a no-op at runtime — no behavior change
- [x] Blog post pages render `<script type="application/ld+json">` with BlogPosting schema
- [x] `/robots.txt` shows AI crawler user-agent blocks
- [x] Validate ArticleJsonLd with Google Rich Results Test (post-deploy)