### PR TITLE
fix: homepage module layouts, dropdown consistency, country modal

### DIFF
--- a/src/app/[locale]/(main)/blog/[category]/[postSlug]/page.tsx
+++ b/src/app/[locale]/(main)/blog/[category]/[postSlug]/page.tsx
@@ -262,7 +262,7 @@ export default async function PostPage({
 
       {/* Featured Collection Products */}
       {collectionProducts.length > 0 && (
-        <div className="w-full px-2 my-8 md:my-12 xl:my-16 xl:max-w-4xl xl:mx-auto xl:px-4">
+        <div className="w-full px-2 my-8 md:my-12 xl:my-16">
           <div className="py-4 flex justify-between items-center">
             <h2 className="text-black text-sm font-medium">
               {post.featuredCollection?.title || "Featured Products"}

--- a/src/components/CountrySwitcher.tsx
+++ b/src/components/CountrySwitcher.tsx
@@ -97,8 +97,8 @@ export default function CountrySwitcher({ isOpen, onClose }: CountrySwitcherProp
           aria-labelledby="country-modal-title"
           inert={!isOpen ? true : undefined}
           className={
-            "fixed inset-0 bg-white z-50 transform transition-transform duration-300 flex flex-col xl:right-auto xl:w-1/2 overscroll-contain" +
-            (isOpen ? " translate-x-0" : " -translate-x-full")
+            "fixed top-0 right-0 h-[100dvh] w-full xl:w-1/2 bg-white z-50 transform transition-transform duration-300 flex flex-col overscroll-contain" +
+            (isOpen ? " translate-x-0" : " translate-x-full")
           }
         >
           <ModalHeader

--- a/src/components/header/DesktopDropdown.tsx
+++ b/src/components/header/DesktopDropdown.tsx
@@ -110,7 +110,7 @@ export default function DesktopDropdown({
         </div>
 
         {/* Right side - Latest 4 editorials with images */}
-        <div className="w-[70vw]">
+        <div className="w-[60vw]">
           <p className="text-xs mb-2">Latest Editorials</p>
           <div className="grid grid-cols-4 gap-1">
             {blogPosts?.slice(0, 4).map((post) => {
@@ -123,7 +123,7 @@ export default function DesktopDropdown({
                   className="group"
                   onClick={onClose}
                 >
-                  <div className="aspect-[2/3] relative overflow-hidden">
+                  <div className="aspect-[3/4] relative overflow-hidden">
                     {post.featuredImage?.asset?.url ? (
                       <Image
                         src={post.featuredImage.asset.url}

--- a/src/components/header/DropdownContent.tsx
+++ b/src/components/header/DropdownContent.tsx
@@ -171,7 +171,7 @@ const DropdownContent = memo(function DropdownContent({
       </div>
 
       {/* Featured Collections Column - Right side */}
-      <div className="w-[50vw]">
+      <div className="w-[60vw]">
         <p className="text-xs mb-3 mt-2">Featured Collections</p>
         <div className="grid grid-cols-4 gap-1">
           {featuredCollections?.slice(0, 4).map((collection) => {

--- a/src/components/homepage/ContentModule.tsx
+++ b/src/components/homepage/ContentModule.tsx
@@ -125,19 +125,19 @@ function ProductsContent({
   const hasDifferentLayouts = mobileDisplayType !== desktopDisplayType;
 
   const containerClass = isSplit
-    ? "w-full xl:w-[50vw] flex-shrink-0"
+    ? "w-full flex-shrink-0"
     : "w-full";
 
   const renderHeader = () =>
     (module.featuredHeading || module.featuredButtonText) && (
       <div className="flex justify-between items-center mb-4">
         {module.featuredHeading && (
-          <h2 className="text-black text-sm">{module.featuredHeading}</h2>
+          <h2 className="text-black text-sm overflow-hidden min-w-0">{module.featuredHeading}</h2>
         )}
         {module.featuredButtonText && (
           <LocaleLink
             href={module.featuredButtonLink || "/products"}
-            className="text-black text-xs hover:underline cursor-pointer"
+            className="text-black text-xs hover:underline cursor-pointer whitespace-nowrap flex-shrink-0"
           >
             {module.featuredButtonText}
           </LocaleLink>

--- a/src/components/homepage/EditorialModule.tsx
+++ b/src/components/homepage/EditorialModule.tsx
@@ -145,7 +145,7 @@ const EditorialModuleComponent = memo(function EditorialModuleComponent({
                 draggable={false}
               >
                 <article>
-                  <div className="relative h-[40vh] md:h-[45vh] xl:h-[50vh] overflow-hidden">
+                  <div className="relative aspect-[3/4] overflow-hidden">
                     {selectedImage.url && (
                       <Image
                         src={selectedImage.url}


### PR DESCRIPTION
## Summary
- **ContentModule**: fix "View collection" link clipping by removing overflow-causing `50vw` width + add `flex-shrink-0`
- **EditorialModule**: replace `vh`-based image heights with `aspect-[3/4]` for consistent proportions across screen sizes
- **DesktopDropdown**: align Our Space editorial images to `aspect-[3/4]` and `w-[60vw]`
- **DropdownContent**: increase Featured Collections width to `w-[60vw]` matching Our Space
- **CountrySwitcher**: slide modal from right side (matching Cart/Search pattern)
- **Blog post**: make featured products section full-width (remove `max-w-4xl` constraint)

6 files changed

Build passes ✓

## Test plan
- [x] Homepage: "View collection" text fully visible, not clipped
- [x] Homepage: editorial images maintain consistent aspect ratio on window resize
- [x] Desktop dropdown: Our Space and Featured Collections images consistent size
- [x] Country switcher: slides in from right side
- [x] Blog post: featured products span full width
- [x] `bun build` passes