### PR TITLE
fix: blog image sizes, mobile menu collection titles and scroll

### DIFF
--- a/src/app/[locale]/(main)/blog/page.tsx
+++ b/src/app/[locale]/(main)/blog/page.tsx
@@ -50,7 +50,7 @@ export default async function BlogPage() {
               <LocaleLink
                 href={`/blog/${post.category?.slug?.current}/${post.slug?.current}`}
               >
-                <div className="relative w-full h-[50vh] xl:h-[60vh] mb-4 overflow-hidden">
+                <div className="relative w-full aspect-[3/4] mb-4 overflow-hidden">
                   {imageUrl ? (
                     <Image
                       src={imageUrl}

--- a/src/components/menumodal/GenderMenuContent.tsx
+++ b/src/components/menumodal/GenderMenuContent.tsx
@@ -239,9 +239,9 @@ function GenderMenuContent({
                       onPointerDown={handlePointerDown}
                       onPointerMove={handlePointerMove}
                       draggable={false}
-                      className="flex-shrink-0 w-[70vw] min-w-0 aspect-[3/4] flex flex-col cursor-pointer snap-start"
+                      className="flex-shrink-0 w-[55vw] min-w-0 flex flex-col cursor-pointer snap-start"
                     >
-                      <div className="w-full h-full relative bg-gray-100">
+                      <div className="w-full aspect-[3/4] relative bg-gray-100">
                         {collection.menuImage?.asset?.url ? (
                           <Image
                             src={urlFor(collection.menuImage).url()}
@@ -252,7 +252,7 @@ function GenderMenuContent({
                             }
                             fill
                             className="object-cover"
-                            sizes="70vw"
+                            sizes="55vw"
                             draggable={false}
                           />
                         ) : (


### PR DESCRIPTION
## Summary
- **Blog listing**: replace `vh`-based image heights with `aspect-[3/4]` for consistent proportions across viewports
- **Mobile menu**: fix collection titles not visible — moved `aspect-[3/4]` from link to image container
- **Mobile menu**: reduce collection card width from `70vw` to `55vw` to prevent scroll when all sections collapsed

2 files changed

Build passes ✓

## Test plan
- [x] `/blog` — images maintain 3:4 ratio, don't stretch with viewport height
- [x] Mobile menu → Men tab — collection titles visible below images
- [x] Mobile menu collapsed — no vertical scroll
- [x] Mobile menu expanded — vertical scroll enabled
- [x] `bun build` passes