### PR TITLE
v2.16.1: layout fixes, image consistency, mobile menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zone2run",
-  "version": "2.16.0",
+  "version": "2.16.1",
   "private": true,
   "scripts": {
     "dev": "portless zone2 next dev --turbopack",

--- a/src/app/[locale]/(main)/blog/[category]/[postSlug]/page.tsx
+++ b/src/app/[locale]/(main)/blog/[category]/[postSlug]/page.tsx
@@ -262,7 +262,7 @@ export default async function PostPage({
 
       {/* Featured Collection Products */}
       {collectionProducts.length > 0 && (
-        <div className="w-full px-2 my-8 md:my-12 xl:my-16 xl:max-w-4xl xl:mx-auto xl:px-4">
+        <div className="w-full px-2 my-8 md:my-12 xl:my-16">
           <div className="py-4 flex justify-between items-center">
             <h2 className="text-black text-sm font-medium">
               {post.featuredCollection?.title || "Featured Products"}

--- a/src/app/[locale]/(main)/blog/page.tsx
+++ b/src/app/[locale]/(main)/blog/page.tsx
@@ -50,7 +50,7 @@ export default async function BlogPage() {
               <LocaleLink
                 href={`/blog/${post.category?.slug?.current}/${post.slug?.current}`}
               >
-                <div className="relative w-full h-[50vh] xl:h-[60vh] mb-4 overflow-hidden">
+                <div className="relative w-full aspect-[3/4] mb-4 overflow-hidden">
                   {imageUrl ? (
                     <Image
                       src={imageUrl}

--- a/src/components/CountrySwitcher.tsx
+++ b/src/components/CountrySwitcher.tsx
@@ -97,8 +97,8 @@ export default function CountrySwitcher({ isOpen, onClose }: CountrySwitcherProp
           aria-labelledby="country-modal-title"
           inert={!isOpen ? true : undefined}
           className={
-            "fixed inset-0 bg-white z-50 transform transition-transform duration-300 flex flex-col xl:right-auto xl:w-1/2 overscroll-contain" +
-            (isOpen ? " translate-x-0" : " -translate-x-full")
+            "fixed top-0 right-0 h-[100dvh] w-full xl:w-1/2 bg-white z-50 transform transition-transform duration-300 flex flex-col overscroll-contain" +
+            (isOpen ? " translate-x-0" : " translate-x-full")
           }
         >
           <ModalHeader

--- a/src/components/header/DesktopDropdown.tsx
+++ b/src/components/header/DesktopDropdown.tsx
@@ -110,7 +110,7 @@ export default function DesktopDropdown({
         </div>
 
         {/* Right side - Latest 4 editorials with images */}
-        <div className="w-[70vw]">
+        <div className="w-[60vw]">
           <p className="text-xs mb-2">Latest Editorials</p>
           <div className="grid grid-cols-4 gap-1">
             {blogPosts?.slice(0, 4).map((post) => {
@@ -123,7 +123,7 @@ export default function DesktopDropdown({
                   className="group"
                   onClick={onClose}
                 >
-                  <div className="aspect-[2/3] relative overflow-hidden">
+                  <div className="aspect-[3/4] relative overflow-hidden">
                     {post.featuredImage?.asset?.url ? (
                       <Image
                         src={post.featuredImage.asset.url}

--- a/src/components/header/DropdownContent.tsx
+++ b/src/components/header/DropdownContent.tsx
@@ -171,7 +171,7 @@ const DropdownContent = memo(function DropdownContent({
       </div>
 
       {/* Featured Collections Column - Right side */}
-      <div className="w-[50vw]">
+      <div className="w-[60vw]">
         <p className="text-xs mb-3 mt-2">Featured Collections</p>
         <div className="grid grid-cols-4 gap-1">
           {featuredCollections?.slice(0, 4).map((collection) => {

--- a/src/components/homepage/ContentModule.tsx
+++ b/src/components/homepage/ContentModule.tsx
@@ -125,19 +125,19 @@ function ProductsContent({
   const hasDifferentLayouts = mobileDisplayType !== desktopDisplayType;
 
   const containerClass = isSplit
-    ? "w-full xl:w-[50vw] flex-shrink-0"
+    ? "w-full flex-shrink-0"
     : "w-full";
 
   const renderHeader = () =>
     (module.featuredHeading || module.featuredButtonText) && (
       <div className="flex justify-between items-center mb-4">
         {module.featuredHeading && (
-          <h2 className="text-black text-sm">{module.featuredHeading}</h2>
+          <h2 className="text-black text-sm overflow-hidden min-w-0">{module.featuredHeading}</h2>
         )}
         {module.featuredButtonText && (
           <LocaleLink
             href={module.featuredButtonLink || "/products"}
-            className="text-black text-xs hover:underline cursor-pointer"
+            className="text-black text-xs hover:underline cursor-pointer whitespace-nowrap flex-shrink-0"
           >
             {module.featuredButtonText}
           </LocaleLink>

--- a/src/components/homepage/EditorialModule.tsx
+++ b/src/components/homepage/EditorialModule.tsx
@@ -145,7 +145,7 @@ const EditorialModuleComponent = memo(function EditorialModuleComponent({
                 draggable={false}
               >
                 <article>
-                  <div className="relative h-[40vh] md:h-[45vh] xl:h-[50vh] overflow-hidden">
+                  <div className="relative aspect-[3/4] overflow-hidden">
                     {selectedImage.url && (
                       <Image
                         src={selectedImage.url}

--- a/src/components/menumodal/GenderMenuContent.tsx
+++ b/src/components/menumodal/GenderMenuContent.tsx
@@ -239,9 +239,9 @@ function GenderMenuContent({
                       onPointerDown={handlePointerDown}
                       onPointerMove={handlePointerMove}
                       draggable={false}
-                      className="flex-shrink-0 w-[70vw] min-w-0 aspect-[3/4] flex flex-col cursor-pointer snap-start"
+                      className="flex-shrink-0 w-[55vw] min-w-0 flex flex-col cursor-pointer snap-start"
                     >
-                      <div className="w-full h-full relative bg-gray-100">
+                      <div className="w-full aspect-[3/4] relative bg-gray-100">
                         {collection.menuImage?.asset?.url ? (
                           <Image
                             src={urlFor(collection.menuImage).url()}
@@ -252,7 +252,7 @@ function GenderMenuContent({
                             }
                             fill
                             className="object-cover"
-                            sizes="70vw"
+                            sizes="55vw"
                             draggable={false}
                           />
                         ) : (


### PR DESCRIPTION
## Summary
- **ContentModule**: fix "View collection" link clipping, remove overflow-causing `50vw` width (#174)
- **EditorialModule**: replace `vh`-based image heights with `aspect-[3/4]` (#174)
- **DesktopDropdown**: align Our Space images to `aspect-[3/4]` and `w-[60vw]` (#174)
- **DropdownContent**: increase Featured Collections to `w-[60vw]` (#174)
- **CountrySwitcher**: slide modal from right side (#174)
- **Blog post**: featured products section full-width (#174)
- **Blog listing**: replace `vh` image heights with `aspect-[3/4]` (#175)
- **Mobile menu**: fix collection titles not visible, reduce card width to prevent scroll (#175)

8 files changed, +14 −14

Build passes ✓

## Test plan
- [x] Homepage modules render correctly
- [x] Dropdown images consistent across Men/Women/Our Space
- [x] Country switcher slides from right
- [x] Blog listing images maintain aspect ratio
- [x] Mobile menu collection titles visible
- [x] Mobile menu no scroll when collapsed
- [x] `bun build` passes