### PR TITLE
fix: filter modal interactivity, toast button, touch target density

### DIFF
--- a/src/app/[locale]/(main)/layout.tsx
+++ b/src/app/[locale]/(main)/layout.tsx
@@ -59,7 +59,7 @@ export default async function MainLayout({
       <body>
         <a
           href="#main-content"
-          className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-[100] focus:bg-white focus:px-4 focus:py-2 focus:text-black focus:outline focus:outline-2 focus:outline-black"
+          className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-30 focus:bg-white focus:px-4 focus:py-2 focus:text-black focus:outline focus:outline-2 focus:outline-black"
         >
           Skip to main content
         </a>

--- a/src/components/plp/FilterContent.tsx
+++ b/src/components/plp/FilterContent.tsx
@@ -30,7 +30,7 @@ function FilterPill({
   return (
     <button
       type="button"
-      className={`inline-flex items-center gap-2 px-2 py-2 text-xs transition-colors w-fit min-h-touch-target ${
+      className={`inline-flex items-center gap-2 px-2 py-2 text-xs transition-colors w-fit ${
         isSelected ? "bg-black text-white" : "bg-gray-100 hover:bg-gray-200"
       }`}
       onClick={onToggle}

--- a/src/components/plp/FilterSortModal.tsx
+++ b/src/components/plp/FilterSortModal.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 import dynamic from "next/dynamic";
 import { useEscapeKey } from "@/hooks/useEscapeKey";
 import { useInertBackground } from "@/hooks/useInertBackground";
@@ -48,6 +50,11 @@ export function FilterSortModal({
   activeFilterCount,
 }: FilterSortModalProps) {
   const { unlockScroll } = useModalScrollRestoration();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   const handleClose = () => {
     onClose();
@@ -69,7 +76,9 @@ export function FilterSortModal({
     onSortChange("newest");
   };
 
-  return (
+  if (!mounted) return null;
+
+  return createPortal(
     <>
       <Backdrop isOpen={isOpen} onClick={handleClose} />
       <FocusLock disabled={!isOpen}>
@@ -207,6 +216,7 @@ export function FilterSortModal({
           </div>
         </div>
       </FocusLock>
-    </>
+    </>,
+    document.body,
   );
 }

--- a/src/components/product/AddedToCartModal.tsx
+++ b/src/components/product/AddedToCartModal.tsx
@@ -69,20 +69,20 @@ const AddedToCartModal = memo(function AddedToCartModal({
         )}
         {/* Product Info + Button */}
         <div className="flex flex-col flex-1">
-          <div className="text-left flex flex-col justify-center h-full px-2 mt-4">
+          <div className="text-left flex flex-col justify-center h-full px-2">
             <p className="text-xs font-semibold">{lastAddedProduct.brand}</p>
             <p className="text-xs">{lastAddedProduct.title}</p>
             <p className="text-xs">
               {formatCurrency(lastAddedProduct.price, lastAddedProduct.currencyCode)}
             </p>
             <p className="text-xs">Size: {lastAddedProduct.size}</p>
-            <div className="flex justify-end mt-auto">
+            <div className="flex justify-end mt-auto pr-2 pb-2">
               <button
                 onClick={() => {
                   setIsCartOpen(true);
                   hideAddedToCart();
                 }}
-                className="px-4 py-2 bg-black text-white text-xs cursor-pointer min-h-touch-target"
+                className="px-4 py-2 bg-black text-white text-xs cursor-pointer"
               >
                 View Cart
               </button>

--- a/src/components/product/VariantSelector.tsx
+++ b/src/components/product/VariantSelector.tsx
@@ -82,7 +82,7 @@ const VariantSelector = memo(function VariantSelector({
             <button
               key={size}
               aria-label={`Select size ${size}${!isAvailable ? ", unavailable" : ""}${isSelected ? ", selected" : ""}`}
-              className={`py-2 px-4 border text-center text-xs transition-colors min-h-touch-target ${
+              className={`py-2 px-4 border text-center text-xs transition-colors ${
                 isOneSize ? "w-full" : ""
               } ${
                 !isAvailable


### PR DESCRIPTION
## Summary
- **FilterSortModal**: render via \`createPortal\` to \`document.body\` — was rendered inside \`#main-content\` which gets \`inert\` set when modal opens, breaking ALL modal interactions (close button, filter pills, Apply button)
- **Skip link**: lower \`focus:z-[100]\` to \`focus:z-30\` so it cannot overlay open modals (was flashing visible inside filter modal)
- **AddedToCartModal**: fix "View Cart" button clipping on right edge, remove \`min-h-touch-target\` + \`mt-4\` that squeezed the toast layout
- **VariantSelector**: remove \`min-h-touch-target\` from size pills — was creating chunky 60px buttons that broke PDP design density
- **FilterContent**: same fix for filter pills

5 files changed, +18 −8

Build passes ✓

## Test plan
- [x] PLP filter modal — opens, all controls interactive (close, pills, Clear All, Apply)
- [x] Skip link doesn't appear when modals open
- [x] Add product to cart toast — View Cart button fully visible
- [x] PDP variant size pills render at standard density
- [x] PLP filter pills compact, not 60px tall
- [x] \`bun build\` passes