### PR TITLE
fix: scroll position preservation on modal close and back nav

### DIFF
--- a/src/components/ScrollRestoration.tsx
+++ b/src/components/ScrollRestoration.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { usePathname } from "next/navigation";
 
 export function ScrollRestoration() {
   const pathname = usePathname();
+  const isFirstRender = useRef(true);
+  const isPopStateRef = useRef(false);
 
   useEffect(() => {
     // Reset any body styles that might have been left over from modals
@@ -14,10 +16,26 @@ export function ScrollRestoration() {
     document.body.style.left = "";
     document.body.style.right = "";
 
+    // Track browser back/forward navigation so we can skip scroll-to-top
+    // (the browser's native history API will restore the correct position)
+    const handlePopState = () => {
+      isPopStateRef.current = true;
+    };
+    window.addEventListener("popstate", handlePopState);
+    return () => window.removeEventListener("popstate", handlePopState);
   }, []);
 
-  // Scroll to top on route change
+  // Scroll to top on forward navigation only — let the browser restore
+  // scroll position on back/forward navigation
   useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    if (isPopStateRef.current) {
+      isPopStateRef.current = false;
+      return;
+    }
     window.scrollTo(0, 0);
   }, [pathname]);
 

--- a/src/hooks/useModalScrollRestoration.ts
+++ b/src/hooks/useModalScrollRestoration.ts
@@ -1,13 +1,16 @@
 "use client";
 
+import { usePathname } from "next/navigation";
 import { useScrollStore } from "@/store/scroll";
 
 export function useModalScrollRestoration() {
-  const { scrollY, setScrollY } = useScrollStore();
+  const pathname = usePathname();
+  const { setScrollY, setLockedPathname } = useScrollStore();
 
   const lockScroll = () => {
     const currentScrollY = window.scrollY;
     setScrollY(currentScrollY);
+    setLockedPathname(pathname);
 
     // Calculate scrollbar width before locking
     const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
@@ -29,7 +32,16 @@ export function useModalScrollRestoration() {
   };
 
   const unlockScroll = () => {
-    const savedScrollY = scrollY;
+    // Read fresh values from the store at call time (not stale closure values)
+    const { scrollY: savedScrollY, lockedPathname } = useScrollStore.getState();
+    const currentPathname = window.location.pathname;
+    const wasLockedOnThisPage =
+      lockedPathname !== null &&
+      // Compare ignoring locale prefix since usePathname returns locale-less paths
+      (lockedPathname === currentPathname ||
+        currentPathname.endsWith(lockedPathname) ||
+        lockedPathname.endsWith(currentPathname));
+    setLockedPathname(null);
 
     // Reset body styles
     document.body.style.position = "";
@@ -45,8 +57,12 @@ export function useModalScrollRestoration() {
       (header as HTMLElement).style.paddingRight = "";
     }
 
-    // Restore scroll
-    window.scrollTo(0, savedScrollY);
+    // Only restore scroll if we're still on the same page
+    // If the user navigated away (e.g., clicked a link in the modal),
+    // the new page should start at its own scroll position (top)
+    if (wasLockedOnThisPage) {
+      window.scrollTo(0, savedScrollY);
+    }
   };
 
   return { lockScroll, unlockScroll };

--- a/src/store/scroll.ts
+++ b/src/store/scroll.ts
@@ -5,9 +5,14 @@ import { create } from "zustand";
 interface ScrollStore {
   scrollY: number;
   setScrollY: (y: number) => void;
+  /** Pathname captured at lock time. Null when nothing is locked. */
+  lockedPathname: string | null;
+  setLockedPathname: (p: string | null) => void;
 }
 
 export const useScrollStore = create<ScrollStore>((set) => ({
   scrollY: 0,
   setScrollY: (y) => set({ scrollY: y }),
+  lockedPathname: null,
+  setLockedPathname: (p) => set({ lockedPathname: p }),
 }));


### PR DESCRIPTION
## Summary
Two scroll position bugs fixed:

### 1. Menu → brand link on mobile jumped to footer then to top
When clicking a brand link from mobile menu with scroll > 0, the modal's \`unlockScroll()\` was restoring the homepage's scroll position onto the newly-loaded brand page (landing near the footer), then \`ScrollRestoration.tsx\` fired \`scrollTo(0, 0)\` causing a visible jump.

Fix: \`useModalScrollRestoration\` now tracks the pathname at lock time (via Zustand store so lock/unlock work across separate hook instances in Header vs Modal). In \`unlockScroll\`, we compare to current pathname — if it changed during the modal's lifecycle, we skip the scroll restore and let the new page start at its own position.

### 2. Back navigation reset scroll to top
\`ScrollRestoration.tsx\` ran \`window.scrollTo(0, 0)\` on every pathname change, destroying the browser's native back/forward scroll restoration.

Fix: Listen for \`popstate\` events. When popstate fires (browser back/forward), skip the scroll-to-top so the browser can restore the correct position.

## Files changed
- \`src/components/ScrollRestoration.tsx\` — detect popstate, skip scroll-to-top on back/forward
- \`src/hooks/useModalScrollRestoration.ts\` — pathname-aware scroll restore
- \`src/store/scroll.ts\` — add \`lockedPathname\` state

3 files, +45 −6

Build passes ✓

## Test plan
- [x] Mobile: scroll homepage → open menu → click brand → lands at TOP of brand page (no jump)
- [x] Mobile: scroll homepage → open menu → click X → stays at homepage scroll position
- [x] Mobile: scroll homepage → open menu → click brand → browser back → returns to homepage scroll position
- [x] Same flows with cart, search, country modals
- [x] Desktop: no regression
- [x] \`bun build\` passes