### PR TITLE
v2.16.3: filter modal, scroll restoration, touch target density

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zone2run",
-  "version": "2.16.2",
+  "version": "2.16.3",
   "private": true,
   "scripts": {
     "dev": "portless zone2 next dev --turbopack",

--- a/src/app/[locale]/(main)/layout.tsx
+++ b/src/app/[locale]/(main)/layout.tsx
@@ -59,7 +59,7 @@ export default async function MainLayout({
       <body>
         <a
           href="#main-content"
-          className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-[100] focus:bg-white focus:px-4 focus:py-2 focus:text-black focus:outline focus:outline-2 focus:outline-black"
+          className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-30 focus:bg-white focus:px-4 focus:py-2 focus:text-black focus:outline focus:outline-2 focus:outline-black"
         >
           Skip to main content
         </a>

--- a/src/components/ScrollRestoration.tsx
+++ b/src/components/ScrollRestoration.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { usePathname } from "next/navigation";
 
 export function ScrollRestoration() {
   const pathname = usePathname();
+  const isFirstRender = useRef(true);
+  const isPopStateRef = useRef(false);
 
   useEffect(() => {
     // Reset any body styles that might have been left over from modals
@@ -14,10 +16,26 @@ export function ScrollRestoration() {
     document.body.style.left = "";
     document.body.style.right = "";
 
+    // Track browser back/forward navigation so we can skip scroll-to-top
+    // (the browser's native history API will restore the correct position)
+    const handlePopState = () => {
+      isPopStateRef.current = true;
+    };
+    window.addEventListener("popstate", handlePopState);
+    return () => window.removeEventListener("popstate", handlePopState);
   }, []);
 
-  // Scroll to top on route change
+  // Scroll to top on forward navigation only — let the browser restore
+  // scroll position on back/forward navigation
   useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    if (isPopStateRef.current) {
+      isPopStateRef.current = false;
+      return;
+    }
     window.scrollTo(0, 0);
   }, [pathname]);
 

--- a/src/components/plp/FilterContent.tsx
+++ b/src/components/plp/FilterContent.tsx
@@ -30,7 +30,7 @@ function FilterPill({
   return (
     <button
       type="button"
-      className={`inline-flex items-center gap-2 px-2 py-2 text-xs transition-colors w-fit min-h-touch-target ${
+      className={`inline-flex items-center gap-2 px-2 py-2 text-xs transition-colors w-fit ${
         isSelected ? "bg-black text-white" : "bg-gray-100 hover:bg-gray-200"
       }`}
       onClick={onToggle}

--- a/src/components/plp/FilterSortModal.tsx
+++ b/src/components/plp/FilterSortModal.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 import dynamic from "next/dynamic";
 import { useEscapeKey } from "@/hooks/useEscapeKey";
 import { useInertBackground } from "@/hooks/useInertBackground";
@@ -48,6 +50,11 @@ export function FilterSortModal({
   activeFilterCount,
 }: FilterSortModalProps) {
   const { unlockScroll } = useModalScrollRestoration();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   const handleClose = () => {
     onClose();
@@ -69,7 +76,9 @@ export function FilterSortModal({
     onSortChange("newest");
   };
 
-  return (
+  if (!mounted) return null;
+
+  return createPortal(
     <>
       <Backdrop isOpen={isOpen} onClick={handleClose} />
       <FocusLock disabled={!isOpen}>
@@ -207,6 +216,7 @@ export function FilterSortModal({
           </div>
         </div>
       </FocusLock>
-    </>
+    </>,
+    document.body,
   );
 }

--- a/src/components/product/AddedToCartModal.tsx
+++ b/src/components/product/AddedToCartModal.tsx
@@ -69,20 +69,20 @@ const AddedToCartModal = memo(function AddedToCartModal({
         )}
         {/* Product Info + Button */}
         <div className="flex flex-col flex-1">
-          <div className="text-left flex flex-col justify-center h-full px-2 mt-4">
+          <div className="text-left flex flex-col justify-center h-full px-2">
             <p className="text-xs font-semibold">{lastAddedProduct.brand}</p>
             <p className="text-xs">{lastAddedProduct.title}</p>
             <p className="text-xs">
               {formatCurrency(lastAddedProduct.price, lastAddedProduct.currencyCode)}
             </p>
             <p className="text-xs">Size: {lastAddedProduct.size}</p>
-            <div className="flex justify-end mt-auto">
+            <div className="flex justify-end mt-auto pr-2 pb-2">
               <button
                 onClick={() => {
                   setIsCartOpen(true);
                   hideAddedToCart();
                 }}
-                className="px-4 py-2 bg-black text-white text-xs cursor-pointer min-h-touch-target"
+                className="px-4 py-2 bg-black text-white text-xs cursor-pointer"
               >
                 View Cart
               </button>

--- a/src/components/product/VariantSelector.tsx
+++ b/src/components/product/VariantSelector.tsx
@@ -82,7 +82,7 @@ const VariantSelector = memo(function VariantSelector({
             <button
               key={size}
               aria-label={`Select size ${size}${!isAvailable ? ", unavailable" : ""}${isSelected ? ", selected" : ""}`}
-              className={`py-2 px-4 border text-center text-xs transition-colors min-h-touch-target ${
+              className={`py-2 px-4 border text-center text-xs transition-colors ${
                 isOneSize ? "w-full" : ""
               } ${
                 !isAvailable

--- a/src/hooks/useModalScrollRestoration.ts
+++ b/src/hooks/useModalScrollRestoration.ts
@@ -1,13 +1,16 @@
 "use client";
 
+import { usePathname } from "next/navigation";
 import { useScrollStore } from "@/store/scroll";
 
 export function useModalScrollRestoration() {
-  const { scrollY, setScrollY } = useScrollStore();
+  const pathname = usePathname();
+  const { setScrollY, setLockedPathname } = useScrollStore();
 
   const lockScroll = () => {
     const currentScrollY = window.scrollY;
     setScrollY(currentScrollY);
+    setLockedPathname(pathname);
 
     // Calculate scrollbar width before locking
     const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
@@ -29,7 +32,16 @@ export function useModalScrollRestoration() {
   };
 
   const unlockScroll = () => {
-    const savedScrollY = scrollY;
+    // Read fresh values from the store at call time (not stale closure values)
+    const { scrollY: savedScrollY, lockedPathname } = useScrollStore.getState();
+    const currentPathname = window.location.pathname;
+    const wasLockedOnThisPage =
+      lockedPathname !== null &&
+      // Compare ignoring locale prefix since usePathname returns locale-less paths
+      (lockedPathname === currentPathname ||
+        currentPathname.endsWith(lockedPathname) ||
+        lockedPathname.endsWith(currentPathname));
+    setLockedPathname(null);
 
     // Reset body styles
     document.body.style.position = "";
@@ -45,8 +57,12 @@ export function useModalScrollRestoration() {
       (header as HTMLElement).style.paddingRight = "";
     }
 
-    // Restore scroll
-    window.scrollTo(0, savedScrollY);
+    // Only restore scroll if we're still on the same page
+    // If the user navigated away (e.g., clicked a link in the modal),
+    // the new page should start at its own scroll position (top)
+    if (wasLockedOnThisPage) {
+      window.scrollTo(0, savedScrollY);
+    }
   };
 
   return { lockScroll, unlockScroll };

--- a/src/store/scroll.ts
+++ b/src/store/scroll.ts
@@ -5,9 +5,14 @@ import { create } from "zustand";
 interface ScrollStore {
   scrollY: number;
   setScrollY: (y: number) => void;
+  /** Pathname captured at lock time. Null when nothing is locked. */
+  lockedPathname: string | null;
+  setLockedPathname: (p: string | null) => void;
 }
 
 export const useScrollStore = create<ScrollStore>((set) => ({
   scrollY: 0,
   setScrollY: (y) => set({ scrollY: y }),
+  lockedPathname: null,
+  setLockedPathname: (p) => set({ lockedPathname: p }),
 }));


### PR DESCRIPTION
## Summary
- **FilterSortModal**: render via \`createPortal\` to escape inert background and make all modal interactions clickable (#179)
- **Skip link**: lower z-index so it cannot overlay open modals (#179)
- **AddedToCartModal**: fix "View Cart" button clipping on right edge (#179)
- **VariantSelector + FilterContent**: remove \`min-h-touch-target\` to restore proper design density (#179)
- **Scroll restoration**: menu → brand link no longer jumps to footer then snaps up (#182)
- **Back navigation**: browser back restores previous scroll position instead of jumping to top (#182)

8 files changed

Build passes ✓

## Test plan
- [x] PLP filter modal interactive (close, pills, Apply, Clear All)
- [x] Add to cart toast shows View Cart fully
- [x] PDP variant pills standard density
- [x] Mobile: scroll homepage → menu → brand → no jump
- [x] Browser back preserves scroll position
- [x] \`bun build\` passes