### PR TITLE
perf: quiet geometry-honest fallbacks + inline CSS (post-migration fix round)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -27,6 +27,10 @@ const nextConfig = {
   },
 
   experimental: {
+    // Vercel's Next 16.3 pipeline emits granular immutable CSS chunks (6 render-
+    // blocking stylesheets on staging vs 1 locally) — inlining removes the CSS
+    // request chain from first paint entirely
+    inlineCss: true,
     optimizePackageImports: [
       "@sanity/client",
       "@sanity/visual-editing",

--- a/src/app/[locale]/(main)/blog/[category]/[postSlug]/loading.tsx
+++ b/src/app/[locale]/(main)/blog/[category]/[postSlug]/loading.tsx
@@ -1,7 +1,9 @@
+// Quiet fallback (no skeletons by design): reserve the hero's space as
+// whitespace so the streamed post replaces it without reflow.
 export default function Loading() {
   return (
     <div className="min-h-screen">
-      <div className="w-full h-[60vh] bg-gray-100 animate-pulse mb-8 md:mb-12 xl:mb-16" />
+      <div className="w-full h-[60vh] mb-8 md:mb-12 xl:mb-16" />
     </div>
   );
 }

--- a/src/app/[locale]/(main)/brands/[slug]/loading.tsx
+++ b/src/app/[locale]/(main)/brands/[slug]/loading.tsx
@@ -1,3 +1,5 @@
+import PLPFallback from "@/components/plp/PLPFallback";
+
 export default function Loading() {
-  return <div className="min-h-screen" />;
+  return <PLPFallback />;
 }

--- a/src/app/[locale]/(main)/brands/[slug]/page.tsx
+++ b/src/app/[locale]/(main)/brands/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import PLPFallback from "@/components/plp/PLPFallback";
 import { Suspense } from "react";
 import { getProductsByBrand, getBrandBySlug } from "@/sanity/lib/getData";
 import { notFound } from "next/navigation";
@@ -147,7 +148,7 @@ export default async function BrandPage({
       </div>
 
       {/* Products grid streams in via Suspense */}
-      <Suspense fallback={<div className="min-h-screen" />}>
+      <Suspense fallback={<PLPFallback />}>
         <BrandProductGrid
           decodedSlug={decodedSlug}
           editorialImages={editorialImages}

--- a/src/app/[locale]/(main)/collections/[slug]/loading.tsx
+++ b/src/app/[locale]/(main)/collections/[slug]/loading.tsx
@@ -1,3 +1,5 @@
+import PLPFallback from "@/components/plp/PLPFallback";
+
 export default function Loading() {
-  return <div className="min-h-screen" />;
+  return <PLPFallback />;
 }

--- a/src/app/[locale]/(main)/collections/[slug]/page.tsx
+++ b/src/app/[locale]/(main)/collections/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import PLPFallback from "@/components/plp/PLPFallback";
 import { Suspense } from "react";
 import { notFound } from "next/navigation";
 import { getCollectionInfo, getCollectionProducts } from "@/sanity/lib/getData";
@@ -150,7 +151,7 @@ export default async function CollectionPage({ params }: CollectionPageProps) {
       </div>
 
       {/* Products grid streams in via Suspense */}
-      <Suspense fallback={<div className="min-h-screen" />}>
+      <Suspense fallback={<PLPFallback />}>
         <CollectionProductGrid
           collectionId={collection._id}
           shopifyId={collection.shopifyId}

--- a/src/app/[locale]/(main)/mens/loading.tsx
+++ b/src/app/[locale]/(main)/mens/loading.tsx
@@ -1,3 +1,5 @@
+import PLPFallback from "@/components/plp/PLPFallback";
+
 export default function Loading() {
-  return <div className="min-h-screen" />;
+  return <PLPFallback />;
 }

--- a/src/app/[locale]/(main)/products/[handle]/loading.tsx
+++ b/src/app/[locale]/(main)/products/[handle]/loading.tsx
@@ -1,18 +1,15 @@
+// Quiet fallback (no skeletons by design): reserves the PDP's gallery/info
+// geometry as whitespace so the streamed page replaces it without reflow.
 export default function Loading() {
   return (
     <div className="xl:flex xl:flex-row">
-      {/* Gallery */}
       <div className="w-full xl:w-1/2">
-        <div className="w-full aspect-[4/5] bg-gray-100 animate-pulse" />
+        <div className="w-full aspect-[4/5]" />
       </div>
-      {/* Product info */}
       <div className="w-full px-2 xl:w-1/2 xl:flex xl:flex-col xl:justify-center xl:items-center">
-        <div className="w-full xl:max-w-md pt-4 space-y-3">
-          <div className="h-3 w-1/3 bg-gray-100 animate-pulse" />
-          <div className="h-4 w-2/3 bg-gray-100 animate-pulse" />
-          <div className="h-3 w-1/4 bg-gray-100 animate-pulse" />
-          <div className="h-10 w-full bg-gray-100 animate-pulse mt-6" />
-          <div className="h-[50px] w-full bg-gray-100 animate-pulse" />
+        <div className="w-full xl:max-w-md pt-4">
+          <div className="h-40" />
+          <div className="h-[50px] mt-6" />
         </div>
       </div>
     </div>

--- a/src/app/[locale]/(main)/search/page.tsx
+++ b/src/app/[locale]/(main)/search/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from "react";
+import PLPFallback from "@/components/plp/PLPFallback";
 import { searchProducts } from "@/lib/actions/search";
 import SearchResults from "./SearchResults";
 import type { Metadata } from "next";
@@ -44,7 +45,7 @@ export default function SearchPage(props: {
   searchParams: Promise<{ q?: string }>;
 }) {
   return (
-    <Suspense fallback={<div className="min-h-screen" />}>
+    <Suspense fallback={<PLPFallback />}>
       <SearchContent params={props.params} searchParams={props.searchParams} />
     </Suspense>
   );

--- a/src/app/[locale]/(main)/womens/loading.tsx
+++ b/src/app/[locale]/(main)/womens/loading.tsx
@@ -1,3 +1,5 @@
+import PLPFallback from "@/components/plp/PLPFallback";
+
 export default function Loading() {
-  return <div className="min-h-screen" />;
+  return <PLPFallback />;
 }

--- a/src/components/plp/PLPFallback.tsx
+++ b/src/components/plp/PLPFallback.tsx
@@ -1,0 +1,32 @@
+/**
+ * Quiet fallback for streamed PLP grids (category, brand, collection, search).
+ *
+ * No skeletons by design (store-wide rule): the old flat `min-h-screen` div
+ * followed the same rule but reserved one untyped block, so the streamed
+ * title/filter/grid re-flowed everything below it (CLS 0.47–0.82 on staging).
+ * This reserves the same geometry the grid will occupy — pure whitespace plus
+ * the one label that is static anyway — so the swap is paint-only.
+ */
+export default function PLPFallback({ cards = 8 }: { cards?: number }) {
+  return (
+    <div className="min-h-screen">
+      <div className="px-2 pt-4">
+        <div className="h-10" />
+        <div className="flex justify-between items-center pt-6">
+          <span className="text-xs">Filter</span>
+          <span className="h-4" />
+        </div>
+      </div>
+      <div className="grid grid-cols-2 xl:grid-cols-4 gap-2 px-2 my-8 md:my-12 xl:my-16">
+        {Array.from({ length: cards }, (_, i) => (
+          <div key={i} className="aspect-[4/5] flex flex-col">
+            <div className="w-full h-full" />
+            <div className="pt-2 pb-4">
+              <div className="h-12" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/utils/genderRouteHelpers.tsx
+++ b/src/lib/utils/genderRouteHelpers.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from "react";
+import PLPFallback from "@/components/plp/PLPFallback";
 import { notFound } from "next/navigation";
 import {
   getProductsByGender,
@@ -34,7 +35,7 @@ export function MainCategoryRoute({
   params: Promise<{ locale: string; mainCategory: string }>;
 }) {
   return (
-    <Suspense fallback={<div className="min-h-screen" />}>
+    <Suspense fallback={<PLPFallback />}>
       <MainCategoryResolver gender={gender} params={params} />
     </Suspense>
   );
@@ -65,7 +66,7 @@ export function SubcategoryRoute({
   params: Promise<{ locale: string; mainCategory: string; subcategory: string }>;
 }) {
   return (
-    <Suspense fallback={<div className="min-h-screen" />}>
+    <Suspense fallback={<PLPFallback />}>
       <SubcategoryResolver gender={gender} params={params} />
     </Suspense>
   );
@@ -97,7 +98,7 @@ export function SpecificCategoryRoute({
   params: CategoryParams;
 }) {
   return (
-    <Suspense fallback={<div className="min-h-screen" />}>
+    <Suspense fallback={<PLPFallback />}>
       <SpecificCategoryResolver gender={gender} params={params} />
     </Suspense>
   );


### PR DESCRIPTION
## Summary
- **Quiet no-skeleton fallbacks**: new `PLPFallback` reserves the streamed grid's exact geometry as whitespace (store rule: no skeletons) — replaces flat `min-h-screen` divs across category Route wrappers, PLP loading files, brand/collection/search pages; PDP + blog-post loading states quieted the same way. CLS-proof by construction (0.037 measured on both previously flagged pages)
- **`experimental.inlineCss`**: Vercel's Next 16.3 pipeline emits 6 render-blocking CSS chunks (immutable layout) vs 1 locally — inlining removes the CSS request chain from first paint. Verified 0 stylesheet links on the Vercel preview build
- **A/B vs staging (same infra, bypass-header access, no SSO contamination)**: PDP perf 76→89 (LCP −2.0s, better than production), brand LCP −0.3s, clothing LCP −0.9s
- Also documented: the earlier "uniform +1s FCP regression" was share-token SSO-hop measurement contamination, not a real regression
- 12 files changed, 1 new component. Build passes ✓

## Test plan
- [X] CLS 0.037 on mens-clothing + brands/nike-acg (was 0.818/0.472)
- [X] 0 render-blocking stylesheets on Vercel preview build
- [X] Lighthouse A/B staging vs preview, 16 validated runs
- [X] e2e 17/17 against production build
- [X] `bun build` passes