### PR TITLE
perf: drop unrendered LQIP from card projections (PLP payload −70%)

### DIFF
--- a/scripts/analyze-plp-payload.ts
+++ b/scripts/analyze-plp-payload.ts
@@ -1,0 +1,43 @@
+// One-off: measure PLP GROQ payload composition (bun run scripts/analyze-plp-payload.ts)
+import { createClient } from "@sanity/client";
+import { PLP_PRODUCT_PROJECTION } from "../src/sanity/lib/groqUtils";
+
+const client = createClient({
+  projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!,
+  dataset: process.env.NEXT_PUBLIC_SANITY_DATASET || "production",
+  apiVersion: "2025-06-12",
+  useCdn: true,
+});
+
+const query = `*[_type == "product" && (gender == $gender || gender == "unisex")] {
+  ${PLP_PRODUCT_PROJECTION}
+} | order(_createdAt desc)`;
+
+const data = await client.fetch(query, { gender: "mens" });
+const bytes = (v: unknown) => Buffer.byteLength(JSON.stringify(v ?? null));
+
+const total = bytes(data);
+let lqipBytes = 0, imgCount = 0, imgBytes = 0, urlBytes = 0;
+let perProductImgs: number[] = [];
+for (const p of data) {
+  const imgs = p.images || [];
+  perProductImgs.push(imgs.length);
+  imgBytes += bytes(imgs);
+  for (const img of imgs) {
+    imgCount++;
+    if (img?.lqip) lqipBytes += Buffer.byteLength(String(img.lqip));
+    if (img?.url) urlBytes += Buffer.byteLength(String(img.url));
+  }
+}
+perProductImgs.sort((a, b) => a - b);
+const mid = perProductImgs[Math.floor(perProductImgs.length / 2)];
+console.log({
+  products: data.length,
+  totalMB: (total / 1048576).toFixed(2),
+  imagesMB: (imgBytes / 1048576).toFixed(2),
+  lqipMB: (lqipBytes / 1048576).toFixed(2),
+  urlMB: (urlBytes / 1048576).toFixed(2),
+  images: imgCount,
+  imgsPerProduct: { median: mid, max: perProductImgs.at(-1) },
+  nonImageMB: ((total - imgBytes) / 1048576).toFixed(2),
+});

--- a/src/sanity/lib/groqUtils.ts
+++ b/src/sanity/lib/groqUtils.ts
@@ -122,12 +122,10 @@ export const PDP_PRODUCT_PROJECTION =
 },
 "images": [{
   "url": coalesce(mainImage.asset->url, store.previewImageUrl),
-  "alt": coalesce(mainImage.alt, store.title),
-  "lqip": mainImage.asset->metadata.lqip
+  "alt": coalesce(mainImage.alt, store.title)
 }] + coalesce(gallery[] {
   "url": asset->url,
-  "alt": coalesce(alt, ^.title),
-  "lqip": asset->metadata.lqip
+  "alt": coalesce(alt, ^.title)
 }, []),
 "options": store.options,
 "variants": ` +
@@ -162,12 +160,10 @@ _id,
 },
 "images": [{
   "url": coalesce(mainImage.asset->url, store.previewImageUrl),
-  "alt": coalesce(mainImage.alt, store.title),
-  "lqip": mainImage.asset->metadata.lqip
+  "alt": coalesce(mainImage.alt, store.title)
 }] + coalesce(gallery[] {
   "url": asset->url,
-  "alt": coalesce(alt, ^.title),
-  "lqip": asset->metadata.lqip
+  "alt": coalesce(alt, ^.title)
 }, []),
 "sizes": store.variants[]->store.option1,
 brand-> {
@@ -199,12 +195,10 @@ _id,
 },
 "images": [{
   "url": coalesce(mainImage.asset->url, store.previewImageUrl),
-  "alt": coalesce(mainImage.alt, store.title),
-  "lqip": mainImage.asset->metadata.lqip
+  "alt": coalesce(mainImage.alt, store.title)
 }] + coalesce(gallery[] {
   "url": asset->url,
-  "alt": coalesce(alt, ^.title),
-  "lqip": asset->metadata.lqip
+  "alt": coalesce(alt, ^.title)
 }, []),
 brand-> {
   name,


### PR DESCRIPTION
## Summary
- **PLP GROQ payload 1.54MB → 0.47MB (−70%)**: `lqip` was selected on every main + gallery image across the card projections but rendered nowhere in any card/grid path (only header blog thumbnails and brand/collection heroes use blur-up, via their own projections)
- mens response exceeded Next's 2MB per-cache-entry cap — the hottest query was silently uncached and category runtime prefetches came back hollow
- Adds `scripts/analyze-plp-payload.ts` (payload composition audit)
- 2 files changed. Build passes ✓

## Test plan
- [X] Payload re-measured: 0.47MB, lqip 0.00MB
- [X] Hero/blog lqip consumers untouched (10 legitimate references remain)
- [X] e2e 17/17 against production build
- [X] `bun build` passes